### PR TITLE
Minor fix: adding variable to avoid DAG Import Errors on init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@
         AIRFLOW_CONN_EXAMPLE_DATABASE_CONN: postgresql://airflow:airflow@postgres:5432/airflow
 
         RO_DOU__DAG_CONF_DIR: /opt/airflow/dags/ro_dou/dag_confs
+        termos_exemplo_variavel: 'exemplo'
 
       volumes:
         - ./src:/opt/airflow/dags/ro_dou_src # for development purpose


### PR DESCRIPTION
![image](https://github.com/gestaogovbr/Ro-dou/assets/14188748/477d8a91-d5dd-4067-9579-f431cdfb819b)
Once we start the service a DAG Import Error appears because the variable `termos_exemplo_variavel` is not set.

I added it to the docker-compose with a value.

Thanks.