### PR TITLE
Create param hide_filter

### DIFF
--- a/dag_confs/examples_and_tests/hide_filters_example.yaml
+++ b/dag_confs/examples_and_tests/hide_filters_example.yaml
@@ -1,0 +1,22 @@
+dag:
+  id: hide_filters_example
+  description: DAG de teste
+  tags:
+    - inlabs
+  schedule: 0 8 * * MON-FRI
+  search:
+    header: HEADER TEXT
+    sources:
+    - INLABS
+    terms:
+    - tecnologia
+    - informação
+    department:
+      - Ministério da Gestão e da Inovação em Serviços Públicos
+      - Ministério da Defesa
+  report:
+    emails:
+      - destination@economia.gov.br
+    attach_csv: True
+    subject: "Teste do Ro-dou"
+    hide_filters: True

--- a/schemas/ro-dou.json
+++ b/schemas/ro-dou.json
@@ -220,6 +220,10 @@
             "skip_null": {
               "type": "boolean",
               "description": "description"
+            },
+            "hide_filters": {
+              "type": "boolean",
+              "description": "description"
             }
           },
           "additionalProperties": false

--- a/src/notification/email_sender.py
+++ b/src/notification/email_sender.py
@@ -74,14 +74,16 @@ class EmailSender(ISender):
 
             if search["header"]:
                 blocks.append(f"<h1>{search['header']}</h1>")
-            if search["department"]:
-                blocks.append(
-                    """<p class="secao-marker">Filtrando resultados somente para:</p>"""
-                )
-                blocks.append("<ul>")
-                for dpt in search["department"]:
-                    blocks.append(f"<li>{dpt}</li>")
-                blocks.append("</ul>")
+
+            if not self.specs.hide_filters:
+                if search["department"]:
+                    blocks.append(
+                        """<p class="secao-marker">Filtrando resultados somente para:</p>"""
+                    )
+                    blocks.append("<ul>")
+                    for dpt in search["department"]:
+                        blocks.append(f"<li>{dpt}</li>")
+                    blocks.append("</ul>")
 
             for group, results in search["result"].items():
 
@@ -90,25 +92,34 @@ class EmailSender(ISender):
                         "Nenhum dos termos pesquisados foi encontrado nesta consulta."
                     )
                 else:
-                    if group != "single_group":
-                        blocks.append("\n")
-                        blocks.append(f"**Grupo: {group}**")
-                        blocks.append("\n\n")
+                    if not self.specs.hide_filters:
+                        if group != "single_group":
+                            blocks.append("\n")
+                            blocks.append(f"**Grupo: {group}**")
+                            blocks.append("\n\n")
 
                     for term, items in results.items():
                         blocks.append("\n")
-                        blocks.append(f"* # Resultados para: {term}")
+                        if not self.specs.hide_filters:
+                            blocks.append(f"* # Resultados para: {term}")
 
                         for item in items:
-                            sec_desc = item["section"]
-                            item_html = f"""
-                                    <p class="secao-marker">{sec_desc}</p>
-                                    ### [{item['title']}]({item['href']})
-                                    <p class='abstract-marker'>{item['abstract']}</p>
-                                    <p class='date-marker'>{item['date']}</p>"""
-                            blocks.append(
-                                textwrap.indent(textwrap.dedent(item_html), " " * 4)
-                            )
+
+                            if not self.specs.hide_filters:
+                                sec_desc = item["section"]
+                                item_html = f"""
+                                        <p class="secao-marker">{sec_desc}</p>
+                                        ### [{item['title']}]({item['href']})
+                                        <p class='abstract-marker'>{item['abstract']}</p>
+                                        <p class='date-marker'>{item['date']}</p>"""
+                                blocks.append(
+                                    textwrap.indent(textwrap.dedent(item_html), " " * 4)
+                                )
+                            else:
+                                item_html = f"### [{item['title']}]({item['href']})"
+                                item_html += f"<p class='abstract-marker'>{item['abstract']}</p><br><br>"
+                                blocks.append(textwrap.dedent(item_html))
+
             blocks.append("---")
 
         return markdown.markdown("\n".join(blocks))

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -44,6 +44,7 @@ class DAGConfig:
     doc_md: str
     dag_tags: Set[str]
     owner: str
+    hide_filters: bool
 
 
 class FileParser(ABC):
@@ -152,6 +153,7 @@ class YAMLParser(FileParser):
         emails = report.get("emails")
         subject = report.get("subject", "Extraçao do DOU")
         attach_csv = report.get("attach_csv", False)
+        hide_filters = report.get("hide_filters", False)
 
         return DAGConfig(
             dag_id=dag_id,
@@ -167,6 +169,7 @@ class YAMLParser(FileParser):
             doc_md=doc_md,
             dag_tags=set(dag_tags),
             owner=owner,
+            hide_filters=hide_filters
         )
 
     def _get_terms_params(self, search) -> Tuple[List[str], str, str]:

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -68,6 +68,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag"},
                 "owner": "",
+                "hide_filters": False,
             },
         ),
         (
@@ -107,6 +108,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag", "projeto_a", "departamento_x"},
                 "owner": "pessoa 1, pessoa 2",
+                "hide_filters": False,
             },
         ),
         (
@@ -149,6 +151,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag"},
                 "owner": "",
+                "hide_filters": False,
             },
         ),
         (
@@ -184,6 +187,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag"},
                 "owner": "",
+                "hide_filters": False,
             },
         ),
         (
@@ -231,6 +235,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 ).strip(),
                 "dag_tags": {"dou", "generated_dag"},
                 "owner": "",
+                "hide_filters": False,
             },
         ),
         (
@@ -269,6 +274,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag"},
                 "owner": "",
+                "hide_filters": False,
             },
         ),
         (
@@ -304,6 +310,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag", "inlabs"},
                 "owner": "cdata",
+                "hide_filters": False,
             },
         ),
         (
@@ -342,6 +349,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag", "inlabs"},
                 "owner": "cdata",
+                "hide_filters": False,
             },
         ),
         (
@@ -401,6 +409,46 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "doc_md": None,
                 "dag_tags": {"dou", "generated_dag", "inlabs"},
                 "owner": "",
+                "hide_filters": False,
+            },
+        ),
+        (
+            "hide_filters_example.yaml",
+            {
+                "dag_id": "hide_filters_example",
+                "search": [
+                    {
+                        "terms": ["tecnologia", "informação"],
+                        "header": "HEADER TEXT",
+                        "sources": ["INLABS"],
+                        "sql": None,
+                        "conn_id": None,
+                        "territory_id": None,
+                        "dou_sections": ["TODOS"],
+                        "search_date": "DIA",
+                        "field": "TUDO",
+                        "is_exact_search": True,
+                        "ignore_signature_match": False,
+                        "force_rematch": None,
+                        "full_text": None,
+                        "department": [
+                            "Ministério da Gestão e da Inovação em Serviços Públicos",
+                            "Ministério da Defesa",
+                        ],
+                    }
+                ],
+                "emails": ["destination@economia.gov.br"],
+                "subject": "Teste do Ro-dou",
+                "attach_csv": True,
+                "discord_webhook": None,
+                "slack_webhook": None,
+                "schedule": "0 8 * * MON-FRI",
+                "description": "DAG de teste",
+                "skip_null": True,
+                "doc_md": None,
+                "dag_tags": {"dou", "inlabs", "generated_dag"},
+                "owner": "",
+                "hide_filters": True,
             },
         ),
     ],


### PR DESCRIPTION
Create boolean parameter **hide_filter** for hiding filter and metadata values, like 'resultados para:', 'filtrando por unidades', date.
Only in email template reporting.

Fix issue #89 