### PR TITLE
Force justify text

### DIFF
--- a/src/notification/email_sender.py
+++ b/src/notification/email_sender.py
@@ -113,7 +113,7 @@ class EmailSender(ISender):
                                 item_html = f"""
                                         <p class="secao-marker">{sec_desc}</p>
                                         ### [{item['title']}]({item['href']})
-                                        <p class='abstract-marker'>{item['abstract']}</p>
+                                        <p style='text-align:justify' class='abstract-marker'>{item['abstract']}</p>
                                         <p class='date-marker'>{item['date']}</p>"""
                                 blocks.append(
                                     textwrap.indent(textwrap.dedent(item_html), " " * 4)
@@ -121,7 +121,7 @@ class EmailSender(ISender):
                             else:
                                 item_html = f"""
                                     ### [{item['title']}]({item['href']})
-                                    <p class='abstract-marker'>{item['abstract']}</p><br><br>"""
+                                    <p style='text-align:justify' class='abstract-marker'>{item['abstract']}</p><br><br>"""
                                 blocks.append(textwrap.dedent(item_html))
 
         blocks.append("---")


### PR DESCRIPTION
Besides justifying text in the CSS file, for some email clients like Outlook, it is necessary to force justification in the inline HTML tag.