### PR TITLE
Include parameter for dynamic no result text in notification

### DIFF
--- a/dag_confs/examples_and_tests/header_and_footer_example.yaml
+++ b/dag_confs/examples_and_tests/header_and_footer_example.yaml
@@ -10,12 +10,10 @@ dag:
     terms:
     - tecnologia
     - informação
-    department:
-      - Ministério da Gestão e da Inovação em Serviços Públicos
-      - Ministério da Defesa
   report:
     emails:
       - destination@economia.gov.br
     subject: "Teste do Ro-dou"
     header_text: <p><strong>Greetings<strong></p>
     footer_text: <p>Best Regards</p>
+    no_results_found_text: No results found

--- a/schemas/ro-dou.json
+++ b/schemas/ro-dou.json
@@ -232,6 +232,10 @@
             "footer_text": {
               "type": "string",
               "description": "description"
+            },
+            "no_results_found_text": {
+              "type": "string",
+              "description": "description"
             }
           },
           "additionalProperties": false

--- a/src/notification/discord_sender.py
+++ b/src/notification/discord_sender.py
@@ -11,6 +11,7 @@ class DiscordSender(ISender):
         self.hide_filters = specs.hide_filters
         self.header_text = specs.header_text
         self.footer_text = specs.footer_text
+        self.no_results_found_text = specs.no_results_found_text
 
     def send(self, search_report: list, report_date: str = None):
         """Parse the content, and send message to Discord"""
@@ -34,7 +35,7 @@ class DiscordSender(ISender):
                         self.send_embeds(items)
                 else:
                     self.send_text(
-                        "**Nenhum dos termos pesquisados foi encontrado nesta consulta**"
+                        f"**{self.no_results_found_text}**"
                     )
 
         if self.footer_text:

--- a/src/notification/email_sender.py
+++ b/src/notification/email_sender.py
@@ -33,7 +33,7 @@ class EmailSender(ISender):
             if items:
                 skip_notification = False
             else:
-                content = "Nenhum dos termos pesquisados foi encontrado."
+                content = self.specs.no_results_found_text
 
         if skip_notification:
             if self.specs.skip_null:
@@ -92,7 +92,7 @@ class EmailSender(ISender):
 
                 if not results:
                     blocks.append(
-                        "<p>Nenhum dos termos pesquisados foi encontrado nesta consulta.</p>"
+                        f"<p>{self.specs.no_results_found_text}.</p>"
                     )
                 else:
                     if not self.specs.hide_filters:

--- a/src/notification/slack_sender.py
+++ b/src/notification/slack_sender.py
@@ -14,6 +14,7 @@ class SlackSender(ISender):
         self.hide_filters = specs.hide_filters
         self.header_text = specs.header_text
         self.footer_text = specs.footer_text
+        self.no_results_found_text = specs.no_results_found_text
 
     def send(self, search_report: list, report_date: str = None):
         """Parse the content, and send message to Slack"""
@@ -37,7 +38,7 @@ class SlackSender(ISender):
                                 self._add_block(item)
                 else:
                     self._add_text(
-                        "Nenhum dos termos pesquisados foi encontrado nesta consulta."
+                        self.no_results_found_text
                     )
 
         if self.footer_text:

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -47,6 +47,7 @@ class DAGConfig:
     hide_filters: bool
     header_text: str
     footer_text: str
+    no_results_found_text: str
 
 
 class FileParser(ABC):
@@ -158,6 +159,10 @@ class YAMLParser(FileParser):
         hide_filters = report.get("hide_filters", False)
         header_text = report.get("header_text", None)
         footer_text = report.get("footer_text", None)
+        no_results_found_text = report.get(
+            "no_results_found_text",
+            "Nenhum dos termos pesquisados foi encontrado nesta consulta",
+        )
 
         return DAGConfig(
             dag_id=dag_id,
@@ -175,7 +180,8 @@ class YAMLParser(FileParser):
             owner=owner,
             hide_filters=hide_filters,
             header_text=header_text,
-            footer_text=footer_text
+            footer_text=footer_text,
+            no_results_found_text=no_results_found_text,
         )
 
     def _get_terms_params(self, search) -> Tuple[List[str], str, str]:

--- a/tests/discord_sender_test.py
+++ b/tests/discord_sender_test.py
@@ -4,125 +4,134 @@ import pytest
 from dags.ro_dou_src.notification.discord_sender import DiscordSender, requests
 from pytest_mock import MockerFixture
 
-WEBHOOK = 'https://some-url.com/xxx'
+WEBHOOK = "https://some-url.com/xxx"
+
 
 @pytest.fixture
 def mocked_specs():
-    Specs = namedtuple('Specs',
-                       ['discord_webhook',
-                        'hide_filters',
-                        'header_text',
-                        'footer_text'])
-    return Specs(WEBHOOK, False, None, None)
+    Specs = namedtuple(
+        "Specs",
+        [
+            "discord_webhook",
+            "hide_filters",
+            "header_text",
+            "footer_text",
+            "no_results_found_text",
+        ],
+    )
+    return Specs(
+        WEBHOOK,
+        False,
+        None,
+        None,
+        "Nenhum dos termos pesquisados foi encontrado nesta consulta.",
+    )
+
 
 def test_send_discord_data(session_mocker: MockerFixture, mocked_specs):
-    session_mocker.patch(
-        'dags.ro_dou_src.notification.discord_sender.requests.post')
+    session_mocker.patch("dags.ro_dou_src.notification.discord_sender.requests.post")
 
     sender = DiscordSender(mocked_specs)
-    sender.send_data(
-        {
-            'content': 'string'
-        })
+    sender.send_data({"content": "string"})
 
     requests.post.assert_called_with(
         WEBHOOK,
         json={
-            'content': 'string',
-            'username': 'Querido Prisma (rodou)',
-        })
+            "content": "string",
+            "username": "Querido Prisma (rodou)",
+        },
+    )
 
 
 def test_send_text_to_discord(session_mocker: MockerFixture, mocked_specs):
-    session_mocker.patch(
-        'dags.ro_dou_src.notification.discord_sender.requests.post')
+    session_mocker.patch("dags.ro_dou_src.notification.discord_sender.requests.post")
 
     sender = DiscordSender(mocked_specs)
-    sender.send_text('string')
+    sender.send_text("string")
 
     requests.post.assert_called_with(
         WEBHOOK,
         json={
-            'content': 'string',
-            'username': 'Querido Prisma (rodou)',
-        })
+            "content": "string",
+            "username": "Querido Prisma (rodou)",
+        },
+    )
 
 
 def test_send_embeds_to_discord(session_mocker: MockerFixture, mocked_specs):
-    session_mocker.patch(
-        'dags.ro_dou_src.notification.discord_sender.requests.post')
+    session_mocker.patch("dags.ro_dou_src.notification.discord_sender.requests.post")
     sender = DiscordSender(mocked_specs)
     items = [
         {
-            'title': 'some title',
-            'abstract': 'some abstract',
-            'href': 'http://some-link.com',
+            "title": "some title",
+            "abstract": "some abstract",
+            "href": "http://some-link.com",
         },
         {
-            'title': 'another title',
-            'abstract': 'another abstract',
-            'href': 'http://another-link.com',
+            "title": "another title",
+            "abstract": "another abstract",
+            "href": "http://another-link.com",
         },
     ]
     sender.send_embeds(items)
 
     embeds = items
     for item in embeds:
-        item['url'] = item.pop('href')
-        item['description'] = item.pop('abstract')
+        item["url"] = item.pop("href")
+        item["description"] = item.pop("abstract")
 
     requests.post.assert_called_with(
         WEBHOOK,
         json={
-            'embeds': embeds,
-            'username': 'Querido Prisma (rodou)',
-        })
+            "embeds": embeds,
+            "username": "Querido Prisma (rodou)",
+        },
+    )
 
 
 def _send_report(specs):
     search_report = [
         {
-            'result': {
-                'single_group': {
-                    'lei de acesso à informação': [
+            "result": {
+                "single_group": {
+                    "lei de acesso à informação": [
                         {
-                            'abstract': 'GOV.BR/CURSO/563REGULAMENTAÇÃO '
-                                        'DA __LEI DE ACESSO À INFORMAÇÃO__ '
-                                        'NOS MUNICÍPIOSA LEI FEDERAL Nº '
-                                        '12REGULAMENTAÇÃO DA LEI Nº 12.527/2011, '
-                                        'A __LEI DE ACESSO À INFORMAÇÃO__ E, '
-                                        'EM BREVE, SERÁ INCORPORADO AO CONTEÚDO',
-                            'date': '2023-01-31',
-                            'href': 'https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3509502/2023-01-31/cd3fe0601a5fd9164b48b77bb14b2f0a78962766.pdf',
-                            'section': 'QD - Edição '
-                                        'ordinária ',
-                            'title': 'Campinas/SP'
+                            "abstract": "GOV.BR/CURSO/563REGULAMENTAÇÃO "
+                            "DA __LEI DE ACESSO À INFORMAÇÃO__ "
+                            "NOS MUNICÍPIOSA LEI FEDERAL Nº "
+                            "12REGULAMENTAÇÃO DA LEI Nº 12.527/2011, "
+                            "A __LEI DE ACESSO À INFORMAÇÃO__ E, "
+                            "EM BREVE, SERÁ INCORPORADO AO CONTEÚDO",
+                            "date": "2023-01-31",
+                            "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3509502/2023-01-31/cd3fe0601a5fd9164b48b77bb14b2f0a78962766.pdf",
+                            "section": "QD - Edição " "ordinária ",
+                            "title": "Campinas/SP",
                         }
                     ],
-                    'lgpd': [
+                    "lgpd": [
                         {
-                            'abstract': 'PESSOAISLEI GERAL DE PROTEÇÃO DE '
-                                        'DADOS PESSOAIS - __LGPD__Nos termos '
-                                        'dos Arts. 7º, 10º e 11º da Lei nº 13',
-                            'date': '2023-01-31',
-                            'href': 'https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3518800/2023-01-31/958a384e1cc0cdb545a282e9bb55ea9aa74d4700.pdf',
-                            'section': 'QD - Edição ordinária ',
-                            'title': 'Guarulhos/SP'
+                            "abstract": "PESSOAISLEI GERAL DE PROTEÇÃO DE "
+                            "DADOS PESSOAIS - __LGPD__Nos termos "
+                            "dos Arts. 7º, 10º e 11º da Lei nº 13",
+                            "date": "2023-01-31",
+                            "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3518800/2023-01-31/958a384e1cc0cdb545a282e9bb55ea9aa74d4700.pdf",
+                            "section": "QD - Edição ordinária ",
+                            "title": "Guarulhos/SP",
                         },
                         {
-                            'abstract': 'cumprimento da Lei Geral de Proteção '
-                                        'de Dados Pessoal (__LGPD__ - Lei nº '
-                                        '13.709, de 14 de agosto de 2018), '
-                                        'alcançaLei 13.709/2018 – Lei Geral de '
-                                        'Proteção de Dados (__LGPD__);VII -  '
-                                        'atribuir no âmbito da “Segurança da '
-                                        'Informação”',
-                            'date': '2023-01-31',
-                            'href': 'https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3556206/2023-01-31/2d0f9088530a78c946ada20ec5558f40c5f92900',
-                            'section': 'QD - Edição ordinária ',
-                            'title': 'Valinhos/SP'
-                        }
-                    ]
+                            "abstract": "cumprimento da Lei Geral de Proteção "
+                            "de Dados Pessoal (__LGPD__ - Lei nº "
+                            "13.709, de 14 de agosto de 2018), "
+                            "alcançaLei 13.709/2018 – Lei Geral de "
+                            "Proteção de Dados (__LGPD__);VII -  "
+                            "atribuir no âmbito da “Segurança da "
+                            "Informação”",
+                            "date": "2023-01-31",
+                            "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3556206/2023-01-31/2d0f9088530a78c946ada20ec5558f40c5f92900",
+                            "section": "QD - Edição ordinária ",
+                            "title": "Valinhos/SP",
+                        },
+                    ],
                 }
             },
             "header": "Test Discord Report",
@@ -133,73 +142,69 @@ def _send_report(specs):
     sender.send(search_report)
 
 
-def test_send_report_to_discord__texts(session_mocker: MockerFixture,
-                                       mocked_specs):
+def test_send_report_to_discord__texts(session_mocker: MockerFixture, mocked_specs):
     session_mocker.patch(
-        'dags.ro_dou_src.notification.discord_sender.DiscordSender.send_text')
+        "dags.ro_dou_src.notification.discord_sender.DiscordSender.send_text"
+    )
     session_mocker.patch(
-        'dags.ro_dou_src.notification.discord_sender.DiscordSender.send_embeds')
+        "dags.ro_dou_src.notification.discord_sender.DiscordSender.send_embeds"
+    )
 
     _send_report(mocked_specs)
 
-    args_list = [
-        call[0][0]
-        for call in DiscordSender.send_text.call_args_list
-    ]
+    args_list = [call[0][0] for call in DiscordSender.send_text.call_args_list]
 
     assert args_list == [
-        '**Test Discord Report**',
-        '**Resultados para: lei de acesso à informação**',
-        '**Resultados para: lgpd**'
+        "**Test Discord Report**",
+        "**Resultados para: lei de acesso à informação**",
+        "**Resultados para: lgpd**",
     ]
 
 
-def test_send_report_to_discord__embeds(session_mocker: MockerFixture,
-                                        mocked_specs):
+def test_send_report_to_discord__embeds(session_mocker: MockerFixture, mocked_specs):
     session_mocker.patch(
-        'dags.ro_dou_src.notification.discord_sender.DiscordSender.send_text')
+        "dags.ro_dou_src.notification.discord_sender.DiscordSender.send_text"
+    )
     session_mocker.patch(
-        'dags.ro_dou_src.notification.discord_sender.DiscordSender.send_embeds')
+        "dags.ro_dou_src.notification.discord_sender.DiscordSender.send_embeds"
+    )
 
     _send_report(mocked_specs)
 
-    args_list = [
-        call[0][0]
-        for call in DiscordSender.send_embeds.call_args_list
-    ]
+    args_list = [call[0][0] for call in DiscordSender.send_embeds.call_args_list]
 
     assert args_list == [
         [
             {
-                'abstract': 'GOV.BR/CURSO/563REGULAMENTAÇÃO DA __LEI DE ACESSO À '
-                    'INFORMAÇÃO__ NOS MUNICÍPIOSA LEI FEDERAL Nº 12REGULAMENTAÇÃO '
-                    'DA LEI Nº 12.527/2011, A __LEI DE ACESSO À INFORMAÇÃO__ E, EM '
-                    'BREVE, SERÁ INCORPORADO AO CONTEÚDO',
-                'date': '2023-01-31',
-                'href': 'https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3509502/2023-01-31/cd3fe0601a5fd9164b48b77bb14b2f0a78962766.pdf',
-                'section': 'QD - Edição ordinária ',
-                'title': 'Campinas/SP'
+                "abstract": "GOV.BR/CURSO/563REGULAMENTAÇÃO DA __LEI DE ACESSO À "
+                "INFORMAÇÃO__ NOS MUNICÍPIOSA LEI FEDERAL Nº 12REGULAMENTAÇÃO "
+                "DA LEI Nº 12.527/2011, A __LEI DE ACESSO À INFORMAÇÃO__ E, EM "
+                "BREVE, SERÁ INCORPORADO AO CONTEÚDO",
+                "date": "2023-01-31",
+                "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3509502/2023-01-31/cd3fe0601a5fd9164b48b77bb14b2f0a78962766.pdf",
+                "section": "QD - Edição ordinária ",
+                "title": "Campinas/SP",
             }
         ],
         [
             {
-                'abstract': 'PESSOAISLEI GERAL DE PROTEÇÃO DE DADOS PESSOAIS - __LGPD__Nos '
-                    'termos dos Arts. 7º, 10º e 11º da Lei nº 13',
-                'date': '2023-01-31',
-                'href': 'https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3518800/2023-01-31/958a384e1cc0cdb545a282e9bb55ea9aa74d4700.pdf',
-                'section': 'QD - Edição ordinária ',
-                'title': 'Guarulhos/SP'
+                "abstract": "PESSOAISLEI GERAL DE PROTEÇÃO DE DADOS PESSOAIS - __LGPD__Nos "
+                "termos dos Arts. 7º, 10º e 11º da Lei nº 13",
+                "date": "2023-01-31",
+                "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3518800/2023-01-31/958a384e1cc0cdb545a282e9bb55ea9aa74d4700.pdf",
+                "section": "QD - Edição ordinária ",
+                "title": "Guarulhos/SP",
             },
             {
-                'abstract': 'cumprimento da Lei Geral de Proteção de Dados Pessoal '
-                    '(__LGPD__ - Lei nº 13.709, de 14 de agosto de 2018), '
-                    'alcançaLei 13.709/2018 – Lei Geral de Proteção de Dados '
-                    '(__LGPD__);VII -  atribuir no âmbito da “Segurança da '
-                    'Informação”',
-                'date': '2023-01-31',
-                'href': 'https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3556206/2023-01-31/2d0f9088530a78c946ada20ec5558f40c5f92900',
-                'section': 'QD - Edição ordinária ',
-                'title': 'Valinhos/SP'
-            }
-        ]
+                "abstract": "cumprimento da Lei Geral de Proteção de Dados Pessoal "
+                "(__LGPD__ - Lei nº 13.709, de 14 de agosto de 2018), "
+                "alcançaLei 13.709/2018 – Lei Geral de Proteção de Dados "
+                "(__LGPD__);VII -  atribuir no âmbito da “Segurança da "
+                "Informação”",
+                "date": "2023-01-31",
+                "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3556206/2023-01-31/2d0f9088530a78c946ada20ec5558f40c5f92900",
+                "section": "QD - Edição ordinária ",
+                "title": "Valinhos/SP",
+            },
+        ],
     ]

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -71,6 +71,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -113,6 +114,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -158,6 +160,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -196,6 +199,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -246,6 +250,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -287,6 +292,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -325,6 +331,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -366,6 +373,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -428,6 +436,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -469,6 +478,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": True,
                 "header_text": None,
                 "footer_text": None,
+                "no_results_found_text": "Nenhum dos termos pesquisados foi encontrado nesta consulta",
             },
         ),
         (
@@ -490,10 +500,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                         "ignore_signature_match": False,
                         "force_rematch": None,
                         "full_text": None,
-                        "department": [
-                            "Ministério da Gestão e da Inovação em Serviços Públicos",
-                            "Ministério da Defesa",
-                        ],
+                        "department": None,
                     }
                 ],
                 "emails": ["destination@economia.gov.br"],
@@ -510,6 +517,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "hide_filters": False,
                 "header_text": "<p><strong>Greetings<strong></p>",
                 "footer_text": "<p>Best Regards</p>",
+                "no_results_found_text": "No results found",
             },
         ),
     ],


### PR DESCRIPTION
- Include a parameter for dynamic "no result" text
- Include a variable called **no_results_found_text** in the notification for Email, Slack, and Discord
- Fix the tests
- Add a parameter in the existing example