### PR TITLE
Close p tag in watermark

### DIFF
--- a/src/notification/email_sender.py
+++ b/src/notification/email_sender.py
@@ -23,7 +23,7 @@ class EmailSender(ISender):
         self.watermark = """
             <p><small>Esta pesquisa foi realizada automaticamente pelo
             <a href="https://gestaogovbr.github.io/Ro-dou/">Ro-DOU</a>
-            </small>
+            </small></p>
         """
 
     def send(self, search_report: list, report_date: str):


### PR DESCRIPTION
Não é estritamente necessário, mas para ficar consistente com o resto do conteúdo do e-mail (que está fechando as tags p).