### PR TITLE
Cria parâmetro para Dataset no Data-Aware Schedulling

### DIFF
--- a/dag_confs/examples_and_tests/inlabs_advanced_search_example.yaml
+++ b/dag_confs/examples_and_tests/inlabs_advanced_search_example.yaml
@@ -3,7 +3,7 @@ dag:
   description: DAG de teste
   tags:
     - inlabs
-  schedule: 0 8 * * MON-FRI
+  dataset: inlabs
   owner:
     - cdata
   search:

--- a/dag_confs/examples_and_tests/inlabs_example.yaml
+++ b/dag_confs/examples_and_tests/inlabs_example.yaml
@@ -4,6 +4,7 @@ dag:
   tags:
     - inlabs
   schedule: 0 8 * * MON-FRI
+  dataset: inlabs
   owner:
     - cdata
   search:

--- a/docs/docs/como_funciona/parametros.md
+++ b/docs/docs/como_funciona/parametros.md
@@ -7,6 +7,7 @@ A página abaixo lista os parâmetros configuráveis nos arquivos YAML:
 * **description**: Descrição da DAG de pesquisa.
 * **doc_md**: Documentação em markdown da DAG para uma descrição mais completa.
 * **schedule**: Agendamento da periodicidade de execução da DAG. Padrão cron (0 8 * * MON-FRI)
+* **dataset**: Agendamento da DAG baseado na atualização de um Dataset do Airflow. Em conjunto com o schedule a execução é condicionada ao schedule e dataset.
 * **tags**: Tags para categorizar a DAG.
 * **owner**: Responsável pela DAG.
 

--- a/schemas/ro-dou.json
+++ b/schemas/ro-dou.json
@@ -30,7 +30,11 @@
         },
         "schedule": {
           "type": "string",
-          "description": "Expressão cron ou nome do Dataset"
+          "description": "Expressão cron"
+        },
+        "dataset": {
+          "type": "string",
+          "description": "Nome do Dataset"
         },
         "search": {
           "oneOf":

--- a/tests/dag_generator_test.py
+++ b/tests/dag_generator_test.py
@@ -32,49 +32,75 @@ def email_sender(report_example):
     email_sender.search_report = report_example
     return email_sender
 
+
 def test_convert_report_dict__returns_list(email_sender):
     tuple_list = email_sender.convert_report_dict_to_tuple_list()
     assert isinstance(tuple_list, list)
+
 
 def test_convert_report_dict__returns_tuples(email_sender):
     tuple_list = email_sender.convert_report_dict_to_tuple_list()
     for tpl in tuple_list:
         assert isinstance(tpl, tuple)
 
+
 def test_convert_report_dict__returns_tuples_of_seven(email_sender):
     tuple_list = email_sender.convert_report_dict_to_tuple_list()
     for tpl in tuple_list:
         assert len(tpl) == 8
+
 
 def test_convert_report_to_dataframe__rows_count(email_sender):
     df = email_sender.convert_report_to_dataframe()
     # num_rows
     assert df.shape[0] == 15
 
+
 def test_convert_report_to_dataframe__cols_single_group(email_sender):
     df = email_sender.convert_report_to_dataframe()
-    assert tuple(df.columns) == ('Consulta', 'Termo de pesquisa', 'Seção', 'URL',
-                                 'Título', 'Resumo', 'Data')
+    assert tuple(df.columns) == (
+        "Consulta",
+        "Termo de pesquisa",
+        "Seção",
+        "URL",
+        "Título",
+        "Resumo",
+        "Data",
+    )
+
 
 def test_convert_report_to_dataframe__cols_grouped_report(email_sender, report_example):
-    report_example[0]['result']['group_name_different_of_single_group'] = \
-        report_example[0]['result'].pop('single_group')
+    report_example[0]["result"]["group_name_different_of_single_group"] = (
+        report_example[0]["result"].pop("single_group")
+    )
     email_sender.search_report = report_example
     df = email_sender.convert_report_to_dataframe()
-    assert tuple(df.columns) == ('Consulta', 'Grupo', 'Termo de pesquisa', 'Seção', 'URL',
-                                 'Título', 'Resumo', 'Data')
+    assert tuple(df.columns) == (
+        "Consulta",
+        "Grupo",
+        "Termo de pesquisa",
+        "Seção",
+        "URL",
+        "Título",
+        "Resumo",
+        "Data",
+    )
+
 
 def test_get_csv_tempfile__valid_file_name_preffix(email_sender):
     with email_sender.get_csv_tempfile() as csv_file:
-        assert csv_file.name.split('/')[-1].startswith('extracao_dou_')
+        assert csv_file.name.split("/")[-1].startswith("extracao_dou_")
+
 
 def test_get_csv_tempfile__valid_file_name_suffix(email_sender):
     with email_sender.get_csv_tempfile() as csv_file:
-        assert csv_file.name.endswith('.csv')
+        assert csv_file.name.endswith(".csv")
+
 
 def test_get_csv_tempfile__valid_csv(email_sender):
     with email_sender.get_csv_tempfile() as csv_file:
         assert pd.read_csv(csv_file.name) is not None
+
 
 def test_merge_results(merge_results_samples):
     merged_result = merge_results(
@@ -82,3 +108,36 @@ def test_merge_results(merge_results_samples):
         merge_results_samples[1],
     )
     assert merged_result == merge_results_samples[2]
+
+
+@pytest.mark.parametrize(
+    "dag_id, size, hashed",
+    [
+        ("unique_id_for_each_dag", 60, 56),
+        ("generates_sparses_hashed_results", 120, 59),
+        ("unique_id_for_each_dag", 10, 6),
+        ("", 10, 0),
+        ("", 100, 0),
+    ],
+)
+def test_hash_dag_id(dag_gen, dag_id, size, hashed):
+    assert dag_gen._hash_dag_id(dag_id, size) == hashed
+
+
+@pytest.mark.parametrize(
+    "dataset, schedule, is_default_schedule",
+    [
+        ("inlabs", "0 8 * * MON-FRI", True),
+        ("inlabs", "0 8 * * MON-FRI", False),
+    ],
+)
+def test_update_schedule_with_dataset(dag_gen, dataset, schedule, is_default_schedule):
+
+    schedule = dag_gen._update_schedule_with_dataset(
+        dataset, schedule, is_default_schedule
+    )
+
+    if is_default_schedule is True:
+        assert isinstance(schedule[0], Dataset)
+    else:
+        assert isinstance(schedule, DatasetOrTimeSchedule)

--- a/tests/dag_generator_test.py
+++ b/tests/dag_generator_test.py
@@ -5,22 +5,25 @@ import pandas as pd
 import pytest
 from dags.ro_dou_src.dou_dag_generator import merge_results
 from dags.ro_dou_src.notification.email_sender import EmailSender, repack_match
+from airflow import Dataset
+from airflow.timetables.datasets import DatasetOrTimeSchedule
 
 
 def test_repack_match(report_example):
-    match_dict = report_example[0]['result']['single_group']['antonio de oliveira'][0]
-    repacked_match = repack_match('Teste Report',
-                                    'single_group',
-                                    'antonio de oliveira',
-                                    match_dict)
-    assert repacked_match == ('Teste Report',
-                              'single_group',
-                              'antonio de oliveira',
-                              'Seção 3',
-                              match_dict['href'],
-                              match_dict['title'],
-                              match_dict['abstract'],
-                              match_dict['date'])
+    match_dict = report_example[0]["result"]["single_group"]["antonio de oliveira"][0]
+    repacked_match = repack_match(
+        "Teste Report", "single_group", "antonio de oliveira", match_dict
+    )
+    assert repacked_match == (
+        "Teste Report",
+        "single_group",
+        "antonio de oliveira",
+        "Seção 3",
+        match_dict["href"],
+        match_dict["title"],
+        match_dict["abstract"],
+        match_dict["date"],
+    )
 
 
 @pytest.fixture

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -5,7 +5,7 @@ import os
 import sys
 import inspect
 import textwrap
-
+import yaml
 import pytest
 
 currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
@@ -13,19 +13,6 @@ parentdir = os.path.dirname(currentdir)
 sys.path.insert(0, parentdir)
 from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
 
-
-@pytest.mark.parametrize(
-    "dag_id, size, hashed",
-    [
-        ("unique_id_for_each_dag", 60, 56),
-        ("generates_sparses_hashed_results", 120, 59),
-        ("unique_id_for_each_dag", 10, 6),
-        ("", 10, 0),
-        ("", 100, 0),
-    ],
-)
-def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
-    assert yaml_parser._hash_dag_id(dag_id, size) == hashed
 
 
 @pytest.mark.parametrize(
@@ -63,7 +50,8 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "attach_csv": False,
                 "discord_webhook": None,
                 "slack_webhook": None,
-                "schedule": "37 5 * * *",
+                "schedule": None,
+                "dataset": None,
                 "description": "DAG de teste",
                 "skip_null": True,
                 "doc_md": None,
@@ -108,6 +96,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "discord_webhook": None,
                 "slack_webhook": None,
                 "schedule": "0 8 * * MON-FRI",
+                "dataset": None,
                 "description": "DAG exemplo utilizando todos os demais parâmetros.",
                 "skip_null": True,
                 "doc_md": None,
@@ -154,7 +143,8 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "attach_csv": True,
                 "discord_webhook": None,
                 "slack_webhook": None,
-                "schedule": "2 5 * * *",
+                "schedule": None,
+                "dataset": None,
                 "description": "DAG de teste",
                 "skip_null": True,
                 "doc_md": None,
@@ -194,7 +184,8 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "attach_csv": False,
                 "discord_webhook": None,
                 "slack_webhook": None,
-                "schedule": "29 5 * * *",
+                "schedule": None,
+                "dataset": None,
                 "description": "DAG de teste",
                 "skip_null": False,
                 "doc_md": None,
@@ -238,7 +229,8 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "attach_csv": False,
                 "discord_webhook": None,
                 "slack_webhook": None,
-                "schedule": "10 5 * * *",
+                "schedule": None,
+                "dataset": None,
                 "description": "DAG com documentação em markdown",
                 "skip_null": True,
                 "doc_md": textwrap.dedent(
@@ -289,7 +281,8 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "attach_csv": False,
                 "discord_webhook": None,
                 "slack_webhook": None,
-                "schedule": "59 5 * * *",
+                "schedule": None,
+                "dataset": None,
                 "description": "DAG de teste (filtro por departamento)",
                 "skip_null": True,
                 "doc_md": None,
@@ -330,6 +323,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "discord_webhook": None,
                 "slack_webhook": None,
                 "schedule": "0 8 * * MON-FRI",
+                "dataset": "inlabs",
                 "description": "DAG de teste",
                 "skip_null": True,
                 "doc_md": None,
@@ -372,7 +366,8 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "attach_csv": True,
                 "discord_webhook": None,
                 "slack_webhook": None,
-                "schedule": "0 8 * * MON-FRI",
+                "schedule": None,
+                "dataset": "inlabs",
                 "description": "DAG de teste",
                 "skip_null": True,
                 "doc_md": None,
@@ -438,6 +433,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "discord_webhook": None,
                 "slack_webhook": None,
                 "schedule": "0 8 * * MON-FRI",
+                "dataset": None,
                 "description": "DAG de teste com múltiplas buscas",
                 "skip_null": False,
                 "doc_md": None,
@@ -481,6 +477,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "discord_webhook": None,
                 "slack_webhook": None,
                 "schedule": "0 8 * * MON-FRI",
+                "dataset": None,
                 "description": "DAG de teste",
                 "skip_null": True,
                 "doc_md": None,
@@ -521,6 +518,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
                 "discord_webhook": None,
                 "slack_webhook": None,
                 "schedule": "0 8 * * MON-FRI",
+                "dataset": None,
                 "description": "DAG de teste",
                 "skip_null": True,
                 "doc_md": None,


### PR DESCRIPTION
1. Cria um novo parâmetro **dataset** permitindo data-aware schedulling da DAG baseado em dataset e/ou agendamento cron.
2. Atualiza exemplos utilizando o parâmetro dataset.
3. Refatoração: altera e migra as funções utilizada para tratamento de schedule da classe YamlParser para DouDigestDagGenerator
4. Atualiza os testes
5. Atualiza a DAG **ro-dou_inlabs_load_pg_dag.py** incluindo uma task de verificação da carga do dia do INLABS na base da conexão **inlabs_db**
6. Inclui na DAG **ro-dou_inlabs_load_pg_dag.py** um decorator de Short Circuit para interromper a execução da DAG caso não existam arquivos no portal do INLABS para o dia.