### PR TITLE
Agrupar resultados por unidade

### DIFF
--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -16,6 +16,7 @@ import textwrap
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Union
+from functools import reduce
 import json
 
 import pandas as pd
@@ -30,7 +31,6 @@ from airflow.providers.slack.notifications.slack import SlackNotifier
 from airflow.timetables.datasets import DatasetOrTimeSchedule
 from airflow.timetables.trigger import CronTriggerTimetable
 
-
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from utils.date import get_trigger_date, template_ano_mes_dia_trigger_local_time
 from notification.notifier import Notifier
@@ -38,24 +38,55 @@ from parsers import DAGConfig, YAMLParser
 from searchers import BaseSearcher, DOUSearcher, QDSearcher, INLABSSearcher
 
 
-SearchResult = Dict[str, Dict[str, List[dict]]]
+SearchResult = Dict[str, Dict[str, Dict[str, List[dict]]]]
 
 
-def merge_results(result_1: SearchResult, result_2: SearchResult) -> SearchResult:
-    """Merge search results by group and term as keys"""
-    return {
-        group: _merge_dict(result_1.get(group, {}), result_2.get(group, {}))
-        for group in set((*result_1, *result_2))
-    }
+def merge_results(*dicts: SearchResult) -> SearchResult:
+    """
+    Merge multiple dictionaries and sum/concatenate values of common keys,
+    including nested dictionaries.
+    """
+
+    def merge_two(dict1, dict2):
+        merged = {}
+
+        # Combine keys from both dictionaries
+        all_keys = set(dict1) | set(dict2)
+
+        for key in all_keys:
+            value1 = dict1.get(key)
+
+            value2 = dict2.get(key)
 
 
-def _merge_dict(dict1, dict2):
-    """Merge dictionaries and sum values of common keys"""
-    dict3 = {**dict1, **dict2}
-    for key, value in dict3.items():
-        if key in dict1 and key in dict2:
-            dict3[key] = value + dict1[key]
-    return dict3
+            if isinstance(value1, dict) and isinstance(value2, dict):
+                # If both values are dictionaries, merge them recursively
+                merged[key] = merge_results(value1, value2)
+            elif isinstance(value1, dict) or isinstance(value2, dict):
+                # If one of the values is a dict, prefer the dict (override with dict)
+                merged[key] = value1 if isinstance(value1, dict) else value2
+            else:
+                # Sum or concatenate the values, treating None or missing keys as 0
+                merged[key] = (value1) + (value2)
+
+        return merged
+
+    # Pre-processing step: Filter out dictionaries where the first key's value is empty
+    filtered_dicts = []
+
+    for d in dicts:
+        if d:  # Ensure the dictionary is not empty
+            first_key = next(iter(d))
+            first_value = d.get(first_key)
+            if first_value:  # Only include if the first key's value is non-empty
+                filtered_dicts.append(d)
+
+    # If no dictionaries remain after filtering, return an empty dictionary
+    if not filtered_dicts:
+        return {}
+
+    # Reduce the list of dictionaries by merging them two at a time
+    return reduce(merge_two, filtered_dicts)
 
 
 def result_as_html(specs: DAGConfig) -> bool:
@@ -203,8 +234,7 @@ class DouDigestDagGenerator:
 
         if schedule is None:
             schedule = self._get_safe_schedule(
-                specs=specs,
-                default_schedule=self.DEFAULT_SCHEDULE
+                specs=specs, default_schedule=self.DEFAULT_SCHEDULE
             )
             is_default_schedule = True
         else:
@@ -370,7 +400,6 @@ class DouDigestDagGenerator:
         }
 
         schedule = self._update_schedule(specs)
-
         dag = DAG(
             specs.dag_id,
             default_args=default_args,

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -307,7 +307,6 @@ class INLABSHook(BaseHook):
                 # If use_summary replace texto value by summary value
                 df["texto"] = df["texto"].where(df["ementa"].isnull(), df["ementa"])
             df["display_date_sortable"] = None
-            df["hierarchyList"] = None
 
             if ignore_signature_match:
                 df = df[~((df["matches_assina"]) & (df["count_assina"] == 1))]
@@ -320,7 +319,7 @@ class INLABSHook(BaseHook):
                 "pubdate": "date",
                 "id": "id",
                 "display_date_sortable": "display_date_sortable",
-                "hierarchyList": "hierarchyList",
+                "artcategory": "hierarchyList",
             }
             df.rename(columns=cols_rename, inplace=True)
             cols_output = list(cols_rename.values())

--- a/src/notification/discord_sender.py
+++ b/src/notification/discord_sender.py
@@ -23,20 +23,25 @@ class DiscordSender(ISender):
             if search["header"]:
                 self.send_text(f'**{search["header"]}**')
 
-            for group, results in search["result"].items():
-                if results:
+            for group, search_results in search["result"].items():
+                if not self.hide_filters:
+                    if group != "single_group":
+                        self.send_text(f"**Grupo: {group}**")
+
+                for term, term_results in search_results.items():
                     if not self.hide_filters:
-                        if group != "single_group":
-                            self.send_text(f"**Grupo: {group}**")
-                    for term, items in results.items():
-                        if not self.hide_filters:
-                            if items:
-                                self.send_text(f"**Resultados para: {term}**")
-                        self.send_embeds(items)
-                else:
-                    self.send_text(
-                        f"**{self.no_results_found_text}**"
-                    )
+                        if not term_results:
+                            self.send_text(
+                                f"**{self.no_results_found_text}**"
+                            )
+                        else:
+                            self.send_text(f"**Resultados para: {term}**")
+
+                            for department, results in term_results.items():
+                                if not self.hide_filters and department != 'single_department':
+                                    self.send_text(f"{department}")
+
+                                self.send_embeds(results)
 
         if self.footer_text:
             footer_text = self._remove_html_tags(self.footer_text)

--- a/src/notification/isender.py
+++ b/src/notification/isender.py
@@ -45,14 +45,16 @@ class ISender(ABC):
             dict: A dictionary with the placeholders replaced with formatting tags.
         """
         reports = copy.deepcopy(search_report)
-
         for _, results in reports["result"].items():
-            for _, items in results.items():
-                for item in items:
-                    open_tag, close_tag = self.highlight_tags
-                    item['abstract'] = _fix_missing_spaces(item['abstract']) \
-                        .replace('<%%>', open_tag) \
-                        .replace('</%%>', close_tag)
+            for _,dpt in results.items():
+                for _, items in dpt.items():
+                    for item in items:
+                        open_tag, close_tag = self.highlight_tags
+                        item['abstract'] = _fix_missing_spaces(item['abstract']) \
+                            .replace('<%%>', open_tag) \
+                            .replace('</%%>', close_tag)
+
+        print (reports)
 
         return reports
 

--- a/src/notification/slack_sender.py
+++ b/src/notification/slack_sender.py
@@ -25,21 +25,27 @@ class SlackSender(ISender):
         for search in search_report:
             if search["header"]:
                 self._add_header(search["header"])
-            for group, results in search["result"].items():
-                if results:
-                    if not self.hide_filters:
-                        if group != "single_group":
-                            self._add_header(f"Grupo: {group}")
-                    for term, items in results.items():
-                        if items:
-                            if not self.hide_filters:
-                                self._add_header(f"Termo: {term}")
-                            for item in items:
-                                self._add_block(item)
-                else:
-                    self._add_text(
-                        self.no_results_found_text
-                    )
+
+            for group, search_results in search["result"].items():
+                if not self.hide_filters:
+                    if group != "single_group":
+                        self._add_header(f"Grupo: {group}")
+
+                for term, term_results in search_results.items():
+                    if not term_results:
+                        self._add_text(
+                            self.no_results_found_text
+                        )
+                    else:
+                        if not self.hide_filters:
+                            self._add_header(f"Termo: {term}")
+
+                        for department, results in term_results.items():
+                            if not self.hide_filters and department != 'single_department':
+                                    self._add_header(f"{department}")
+
+                            for result in results:
+                                self._add_block(result)
 
         if self.footer_text:
             footer_text = _remove_html_tags(self.footer_text)

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -377,7 +377,9 @@ class QDSearcher(BaseSearcher):
         return parsed_results
 
     def parse_result(self, result: dict, result_as_email: bool = True) -> dict:
-        section = "extraordinária" if result.get("is_extra_edition", False) else "ordinária"
+        section = (
+            "extraordinária" if result.get("is_extra_edition", False) else "ordinária"
+        )
         if result_as_email:
             abstract = (
                 "<p>" + "</p><p>".join(result["excerpts"]).replace("\n", "") + "</p>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,42 +384,47 @@ def term_n_group():
 def merge_results_samples() -> Tuple[SearchResult, SearchResult, SearchResult]:
     results_dou = {
         'grupo_1': {
-            'term_1': ['result1', 'result2', 'resultn'],
-            'term_2': ['result1', 'result2', 'resultn'],
-            'term_3': ['result1', 'result2', 'resultn'],
+            'term_1': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_2': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_3': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
         },
         'grupo_2': {
-            'term_4': ['result1', 'result2', 'resultn'],
-            'term_5': ['result1', 'result2', 'resultn'],
-            'term_6': ['result1', 'result2', 'resultn'],
+            'term_4': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_5': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_6': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
         }
     }
     results_qd = {
         'grupo_1': {
-            'term_2': ['result1', 'result2', 'resultn'],
-            'term_3': ['result1', 'result2', 'resultn'],
-            'term_10': ['result1', 'result2', 'resultn'],
+            'term_2':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_3':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_10': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
         },
         'grupo_3': {
-            'term_7': ['result1', 'result2', 'resultn'],
-            'term_8': ['result1', 'result2', 'resultn'],
-            'term_9': ['result1', 'result2', 'resultn'],
+            'term_7':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_8':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_9':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}],
+                        "mgi": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
         }
     }
     merged_results = {
         'grupo_2': {
-            'term_4': ['result1', 'result2', 'resultn'],
-            'term_5': ['result1', 'result2', 'resultn'],
-            'term_6': ['result1', 'result2', 'resultn']},
+            'term_4':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_5':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_6':  {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]}
+        },
         'grupo_3': {
-            'term_7': ['result1', 'result2', 'resultn'],
-            'term_8': ['result1', 'result2', 'resultn'],
-            'term_9': ['result1', 'result2', 'resultn']},
+            'term_7': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_8': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_9': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}],
+                        "mgi": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+        },
         'grupo_1': {
-            'term_1': ['result1', 'result2', 'resultn'],
-            'term_2': ['result1', 'result2', 'resultn', 'result1', 'result2', 'resultn'],
-            'term_3': ['result1', 'result2', 'resultn', 'result1', 'result2', 'resultn'],
-            'term_10': ['result1', 'result2', 'resultn']}
+            'term_1': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_2': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}, {'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_3': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}, {'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]},
+            'term_10': {"single_department": [{'key1': 'result1'}, {'key2': 'result2'}, {'key3': 'resultn'}]}
+        }
     }
 
     return (results_dou, results_qd, merged_results)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,235 +65,239 @@ def report_example() -> list:
         {
             "result": {
                 "single_group": {
-                    "antonio de oliveira": [
-                        {
-                            "section": "Seção 3",
-                            "title": "EXTRATO DE COMPROMISSO",
-                            "href": "https://www.in.gov.br/web/dou/-/extrato-de-compromisso-342504508",
-                            "abstract": "ALESSANDRO GLAUCO DOS ANJOS DE VASCONCELOS "
-                                "- Secretário-Executivo Adjunto do Ministério da "
-                                "Saúde; REGINALDO <span class='highlight' style="
-                                "'background:#FFA;'>ANTONIO</span> ... DE <span "
-                                "class='highlight' style='background:#FFA;'>OLIVEIRA"
-                                "</span> FREITAS JUNIOR - Diretor Geral.EXTRATO DE "
-                                "COMPROMISSO PRONAS/PCD: Termo de Compromisso que "
-                                "entre si celebram a União, por intermédio do "
-                                "Ministério da Saúde,...",
-                            "date": "02/09/2021",
-                        },
-                        {
-                            "section": "Seção 3",
-                            "title": "EXTRATO DE INEXIGIBILIDADE DE LICITAÇÃO Nº 4/2021 - UASG 160454",
-                            "href": "https://www.in.gov.br/web/dou/-/extrato-de-inexigibilidade-de-licitacao-n-4/2021-uasg-160454-342420638",
-                            "abstract": "CPF CONTRATADA : 013.872.545-45 MARCOS <span"
-                                " class='highlight' style='background:#FFA;'>ANTONIO"
-                                "</span> DE <span class='highlight' style='background"
-                                ":#FFA;'>OLIVEIRA</span> CARDOSO. Valor: R$ 160.000"
-                                ",00.000,00. CPF CONTRATADA : 000.009.405-69 LEANDRO "
-                                "MACEDO DE FRANCA. Valor: R$ 160.000,00. CPF CONTRATADA"
-                                " : 000.071.195-00 GILMAR DE OLIVEIRA DANTAS. Valor: "
-                                "R$ 160.000,00. CPF CONTRATADA : 000.241.585-2...",
-                            "date": "02/09/2021",
-                        },
-                        {
-                            "section": "Seção 3",
-                            "title": "EXTRATO DE INEXIGIBILIDADE DE LICITAÇÃO Nº 16/2021 - UASG 160173",
-                            "href": "https://www.in.gov.br/web/dou/-/extrato-de-inexigibilidade-de-licitacao-n-16/2021-uasg-160173-342420560",
-                            "abstract": "CPF CONTRATADA : 066.751.274-89 LUIS <span "
-                                "class='highlight' style='background:#FFA;'>ANTONIO"
-                                "</span> DE <span class='highlight' style='background"
-                                ":#FFA;'>OLIVEIRA</span>. Valor: R$ 80.000,00.EXTRATO "
-                                "DE INEXIGIBILIDADE DE LICITAÇÃO Nº 16/2021 - UASG "
-                                "160173 Nº Processo: 64097007173202061 . Objeto: "
-                                "Contratação de prestadores de serviço de coleta, "
-                                "transporte e distribuição de água potável no contexto d...",
-                            "date": "02/09/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "PORTARIA DE PESSOAL SEGES/ME Nº 10.063, DE 31 DE AGOSTO DE 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/portaria-de-pessoal-seges/me-n-10.063-de-31-de-agosto-de-2021-342182206",
-                            "abstract": "que constam do Processo nº 14022.109097/"
-                                "2021-12, resolve: Art. 1º Efetivar o exercício do "
-                                "servidor <span class='highlight' style='background"
-                                ":#FFA;'>ANTONIO</span> ... GABRIEL <span class="
-                                "'highlight' style='background:#FFA;'>OLIVEIRA</span>"
-                                " DOS SANTOS, Analista de Infraestrutura, matrícula "
-                                "SIAPE nº 1664961, na Superintendência competência "
-                                "subdelegada pelo art. 5º da Portaria SEDGG nº "
-                                "17.472, de 21 ...",
-                            "date": "01/09/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "PORTARIA PRT-3/DPR Nº 337, DE 30 DE AGOSTO DE 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/portaria-prt-3/dpr-n-337-de-30-de-agosto-de-2021-341729221",
-                            "abstract": "mpt.mp.br 12 20/09/2021 27/09/2021 Fabrício "
-                                "Borela Pena fabricio.pena@mpt.mp.br 13 27/09/2021 "
-                                "04/10/2021 <span class='highlight' style='background"
-                                ":#FFA;'>Antonio</span> ... Carlos <span class="
-                                "'highlight' style='background:#FFA;'>Oliveira</span>"
-                                " Pereira antonio.pereira@mpt.mp.br 14 04/10/2021 "
-                                "11/10/2021 Rafael Albernaz Carvalho uso das "
-                                "atribuições que lhe foram delegadas pelo artigo "
-                                "1º, §§1º, 2º, X...",
-                            "date": "31/08/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "PORTARIA Nº 291, DE 27 DE AGOSTO DE 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/portaria-n-291-de-27-de-agosto-de-2021-341719697",
-                            "abstract": "Considerando o que consta no Processo 23282."
-                                "011034/2021-49, resolve: Art. 1º Designar o servidor "
-                                "SAMUEL <span class='highlight' style='background:"
-                                "#FFA;'>ANTÔNIO</span> ... AZEVEDO <span class="
-                                "'highlight' style='background:#FFA;'>OLIVEIRA</span>,"
-                                " matrícula SIAPE nº 2265755, para a função de Gerente"
-                                " da Divisão de Acompanhamento uso de suas atribuições"
-                                " legais, de acordo com a Lei nº 12.289, de 20 de ...",
-                            "date": "31/08/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "PORTARIAS DE 20 DE AGOSTO DE 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/portarias-de-20-de-agosto-de-2021-341686751",
-                            "abstract": "da Lei nº 8.112/90, combinado com o art. 3º,"
-                                " § 1º da Emenda Constitucional nº 103/2019, ao "
-                                "servidor <span class='highlight' style='background"
-                                ":#FFA;'>ANTONIO</span> ... LIMA <span class="
-                                "'highlight' style='background:#FFA;'>OLIVEIRA"
-                                "</span>, matrícula SIAPE nº 30772, ocupante do cargo"
-                                " de Assistente Jurídico, Classe S, Padrão nº 71, de"
-                                " 13 de abril de 2018, resolve: Nº 245 - Conceder "
-                                "aposentadoria volu...",
-                            "date": "31/08/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "PORTARIA PRESI Nº 123, de 26 de agosto de 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/portaria-presi-n-123-de-26-de-agosto-de-2021-341642203",
-                            "abstract": "0007022-26.2021.6.07.8100, resolve: Designar,"
-                            " ad referendum do Tribunal, o Juiz de Direito ROQUE "
-                            "FABRÍCIO <span class='highlight' style='background:"
-                            "#FFA;'>ANTONIO</span> ... DE <span class='highlight' "
-                            "style='background:#FFA;'>OLIVEIRA</span> VIEL para "
-                            "exercer, a partir da publicação deste ato, a função de "
-                            "Juiz Substituto da 11ª Zona Eleitoral, ficando dispensada"
-                            " a Juíza de Direito Catarina de Macedo Nogueira Lima e "
-                            "Corrêa, a partir de 1º/08/2021. Des. HUMBERTO ADJUTO ULHÔA",
-                            "date": "30/08/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "PORTARIA DRF/NAT Nº 54, DE 24 DE AGOSTO DE 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/portaria-drf/nat-n-54-de-24-de-agosto-de-2021-341632367",
-                            "abstract": "Araújo Filho ENGENHARIA ELETRÔNICA Leandro "
-                                "Mayron de Oliveira Pinto Leonardo de Barros e Silva "
-                                "Edson"" <span class='highlight' style='background:"
-                                "#FFA;'>Antônio</span> ... de <span class='highlight' "
-                                "style='background:#FFA;'>Oliveira</span> Flávio Gentil"
-                                " de Araújo Filho ENGENHARIA ELETRÔNICA Leandro Mayron"
-                                " de Oliveira Pinto Leonardo ... de Barros e Silva "
-                                "Edson <span class='highlight' style='background:"
-                                "#FFA;'>Antônio</span> de <span class='highlight' "
-                                "style='background:#FFA;'>Oliveira</span> Flávio "
-                                "Gentil de Araújo Filho ENGENHARIA DOS MATERIAIS Gelsoneide",
-                            "date": "30/08/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "PORTARIA nº 1.664 - GAB/REI/IFPI, de 26 de agosto de 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/portaria-n-1.664-gab/rei/ifpi-de-26-de-agosto-de-2021-341621247",
-                            "abstract": "EDUCAÇÃO, CIÊNCIA E TECNOLOGIA DO PIAUÍ, no"
-                                " uso de suas atribuições legais, resolve: Nomear o "
-                                "servidor <span class='highlight' style='background"
-                                ":#FFA;'>ANTÔNIO</span> ... LUÍS <span class="
-                                "'highlight' style='background:#FFA;'>OLIVEIRA</span> "
-                                "DOS REIS, Assistente em Administração, Nível de "
-                                "Classificação D, Nível de Capacitaçãosto de 2021 O "
-                                "REITOR DO INSTITUTO FEDERAL DE EDUCAÇÃO, CIÊNCIA E TECNOLOGI...",
-                            "date": "30/08/2021",
-                        },
-                        {
-                            "section": "Seção 3",
-                            "title": "AVISO DE LICITAÇÃO Tomada de Preço nº 1/2021",
-                            "href": "https://www.in.gov.br/web/dou/-/aviso-de-licitacao-tomada-de-preco-n-1/2021-341567981",
-                            "abstract": "Nacip Raydan-MG, 25 de agosto de 2021 Eduardo"
-                                " <span class='highlight' style='background:#FFA;'>"
-                                "Antônio</span> de <span class='highlight' style="
-                                "'background:#FFA;'>Oliveira</span> Prefeitorna "
-                                "público que realizar. Objeto: Contratação de empresa "
-                                "especializada para Pavimentação em blocos sextavado "
-                                "de concreto nas ruas Ataíde Moreira, Rua Peçanha, "
-                                "Travessa Tiradentes e Ademar Alvarenga, Convênio n°. 88...",
-                            "date": "30/08/2021",
-                        },
-                        {
-                            "section": "Seção 3",
-                            "title": "EDITAL",
-                            "href": "https://www.in.gov.br/web/dou/-/edital-341218450",
-                            "abstract": "TAMARA SILVA DAIELLO ES-017002/O 5 CONTADOR "
-                                "KLAUS XAVIER DE OLIVEIRA ES-011491/O 6 CONTADOR "
-                                "MARCOS <span class='highlight' style='background:"
-                                "#FFA;'>ANTÔNIO</span> ... DE <span class='highlight'"
-                                " style='background:#FFA;'>OLIVEIRA</span> ES-008492/O"
-                                " 7 CONTADOR EDUARDO TRESENA PORCHERA ES-021302/O 8 "
-                                "CONTADOR JOSÉ JOCIMAR PINHEIROEDITAL RELAÇÃO DA "
-                                "CHAPA HABILITADA A CONCORRER AO PLEITO DE RENOVAÇÃO DE ...",
-                            "date": "27/08/2021",
-                        },
-                        {
-                            "section": "Seção 2",
-                            "title": "RESOLUÇÃO ADMINISTRATIVA Nº 208, de 18 de agosto de 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/resolucao-administrativa-n-208-de-18-de-agosto-de-2021-341078554",
-                            "abstract": "Art. 1º Retificar a Resolução Administrativa "
-                                "nº 74/2021/TRT11, referente à aposentadoria do "
-                                "servidor <span class='highlight' style='background:"
-                                "#FFA;'>ANTÔNIO</span> ... JOSÉ <span class="
-                                "'highlight' style='background:#FFA;'>OLIVEIRA</span>"
-                                " DA SILVA, para incluir a vantagem \"opção\" deferida"
-                                " com base no art. 193 da Lei 8.112/90 ... a seguinte"
-                                " redação: \"Art. 1º Conceder aposentadoria voluntária"
-                                " com proventos integrais ao servidor <span class="
-                                "'highlight' style='background:#FFA;'>ANTONIO</span>"
-                                " ... JOSÉ <span class='highlight' style="
-                                "'background:#FFA;'>OLIVEIRA</span> DA SILVA, "
-                                "ocupante do cargo de Técnico Judiciário, Área"
-                                " Administrativa, Sem Especialidade",
-                            "date": "27/08/2021",
-                        },
-                    ],
-                    "dados abertos": [
-                        {
-                            "section": "Seção 1",
-                            "title": "RESOLUÇÃO CEPPDP/ME Nº 1, DE 31 DE AGOSTO DE 2021",
-                            "href": "https://www.in.gov.br/web/dou/-/resolucao-ceppdp/me-n-1-de-31-de-agosto-de-2021-341971457",
-                            "abstract": "revisados Dez/21-Jan/22 3 Produto 11 "
-                                "Definição de diretrizes para elaboração e revisão do "
-                                "Plano de <span class='highlight' style='background:"
-                                "#FFA;'>Dados</span> ... <span class='highlight' "
-                                "style='background:#FFA;'>Abertos</span> do ME, no"
-                                " que diz respeito à divulgação de dados pessoais "
-                                "Dez/21-Jan/22 3 Produto 12 Detalhamentova o Plano "
-                                "de Ações Estruturantes e Entregas do Comitê "
-                                "Estratégico de Priv...",
-                            "date": "01/09/2021",
-                        },
-                        {
-                            "section": "Seção 1",
-                            "title": "RETIFICAÇÃO",
-                            "href": "https://www.in.gov.br/web/dou/-/retificacao-341676133",
-                            "abstract": "de Textos no Sistema Braille Vigente Portaria"
-                                " nº 380 de 27 de novembro de 2018 Publicar o Plano "
-                                "de <span class='highlight' style='background:#FFA;'"
-                                ">Dados</span> ... <span class='highlight' style="
-                                "'background:#FFA;'>Abertos</span> - PDA Vigente "
-                                "Portaria nº 440 de 28 de dezembro de 2018 Instituir"
-                                " a Comissão para ElaboraçãoRETIFICAÇÃO A Portaria nº"
-                                " 15, de 24 de agosto de 2021, publicada no Diário Ofic...",
-                            "date": "31/08/2021",
-                        },
-                    ],
+                    "antonio de oliveira": {
+                        "single_department":[
+                            {
+                                "section": "Seção 3",
+                                "title": "EXTRATO DE COMPROMISSO",
+                                "href": "https://www.in.gov.br/web/dou/-/extrato-de-compromisso-342504508",
+                                "abstract": "ALESSANDRO GLAUCO DOS ANJOS DE VASCONCELOS "
+                                    "- Secretário-Executivo Adjunto do Ministério da "
+                                    "Saúde; REGINALDO <span class='highlight' style="
+                                    "'background:#FFA;'>ANTONIO</span> ... DE <span "
+                                    "class='highlight' style='background:#FFA;'>OLIVEIRA"
+                                    "</span> FREITAS JUNIOR - Diretor Geral.EXTRATO DE "
+                                    "COMPROMISSO PRONAS/PCD: Termo de Compromisso que "
+                                    "entre si celebram a União, por intermédio do "
+                                    "Ministério da Saúde,...",
+                                "date": "02/09/2021",
+                            },
+                            {
+                                "section": "Seção 3",
+                                "title": "EXTRATO DE INEXIGIBILIDADE DE LICITAÇÃO Nº 4/2021 - UASG 160454",
+                                "href": "https://www.in.gov.br/web/dou/-/extrato-de-inexigibilidade-de-licitacao-n-4/2021-uasg-160454-342420638",
+                                "abstract": "CPF CONTRATADA : 013.872.545-45 MARCOS <span"
+                                    " class='highlight' style='background:#FFA;'>ANTONIO"
+                                    "</span> DE <span class='highlight' style='background"
+                                    ":#FFA;'>OLIVEIRA</span> CARDOSO. Valor: R$ 160.000"
+                                    ",00.000,00. CPF CONTRATADA : 000.009.405-69 LEANDRO "
+                                    "MACEDO DE FRANCA. Valor: R$ 160.000,00. CPF CONTRATADA"
+                                    " : 000.071.195-00 GILMAR DE OLIVEIRA DANTAS. Valor: "
+                                    "R$ 160.000,00. CPF CONTRATADA : 000.241.585-2...",
+                                "date": "02/09/2021",
+                            },
+                            {
+                                "section": "Seção 3",
+                                "title": "EXTRATO DE INEXIGIBILIDADE DE LICITAÇÃO Nº 16/2021 - UASG 160173",
+                                "href": "https://www.in.gov.br/web/dou/-/extrato-de-inexigibilidade-de-licitacao-n-16/2021-uasg-160173-342420560",
+                                "abstract": "CPF CONTRATADA : 066.751.274-89 LUIS <span "
+                                    "class='highlight' style='background:#FFA;'>ANTONIO"
+                                    "</span> DE <span class='highlight' style='background"
+                                    ":#FFA;'>OLIVEIRA</span>. Valor: R$ 80.000,00.EXTRATO "
+                                    "DE INEXIGIBILIDADE DE LICITAÇÃO Nº 16/2021 - UASG "
+                                    "160173 Nº Processo: 64097007173202061 . Objeto: "
+                                    "Contratação de prestadores de serviço de coleta, "
+                                    "transporte e distribuição de água potável no contexto d...",
+                                "date": "02/09/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "PORTARIA DE PESSOAL SEGES/ME Nº 10.063, DE 31 DE AGOSTO DE 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/portaria-de-pessoal-seges/me-n-10.063-de-31-de-agosto-de-2021-342182206",
+                                "abstract": "que constam do Processo nº 14022.109097/"
+                                    "2021-12, resolve: Art. 1º Efetivar o exercício do "
+                                    "servidor <span class='highlight' style='background"
+                                    ":#FFA;'>ANTONIO</span> ... GABRIEL <span class="
+                                    "'highlight' style='background:#FFA;'>OLIVEIRA</span>"
+                                    " DOS SANTOS, Analista de Infraestrutura, matrícula "
+                                    "SIAPE nº 1664961, na Superintendência competência "
+                                    "subdelegada pelo art. 5º da Portaria SEDGG nº "
+                                    "17.472, de 21 ...",
+                                "date": "01/09/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "PORTARIA PRT-3/DPR Nº 337, DE 30 DE AGOSTO DE 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/portaria-prt-3/dpr-n-337-de-30-de-agosto-de-2021-341729221",
+                                "abstract": "mpt.mp.br 12 20/09/2021 27/09/2021 Fabrício "
+                                    "Borela Pena fabricio.pena@mpt.mp.br 13 27/09/2021 "
+                                    "04/10/2021 <span class='highlight' style='background"
+                                    ":#FFA;'>Antonio</span> ... Carlos <span class="
+                                    "'highlight' style='background:#FFA;'>Oliveira</span>"
+                                    " Pereira antonio.pereira@mpt.mp.br 14 04/10/2021 "
+                                    "11/10/2021 Rafael Albernaz Carvalho uso das "
+                                    "atribuições que lhe foram delegadas pelo artigo "
+                                    "1º, §§1º, 2º, X...",
+                                "date": "31/08/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "PORTARIA Nº 291, DE 27 DE AGOSTO DE 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/portaria-n-291-de-27-de-agosto-de-2021-341719697",
+                                "abstract": "Considerando o que consta no Processo 23282."
+                                    "011034/2021-49, resolve: Art. 1º Designar o servidor "
+                                    "SAMUEL <span class='highlight' style='background:"
+                                    "#FFA;'>ANTÔNIO</span> ... AZEVEDO <span class="
+                                    "'highlight' style='background:#FFA;'>OLIVEIRA</span>,"
+                                    " matrícula SIAPE nº 2265755, para a função de Gerente"
+                                    " da Divisão de Acompanhamento uso de suas atribuições"
+                                    " legais, de acordo com a Lei nº 12.289, de 20 de ...",
+                                "date": "31/08/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "PORTARIAS DE 20 DE AGOSTO DE 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/portarias-de-20-de-agosto-de-2021-341686751",
+                                "abstract": "da Lei nº 8.112/90, combinado com o art. 3º,"
+                                    " § 1º da Emenda Constitucional nº 103/2019, ao "
+                                    "servidor <span class='highlight' style='background"
+                                    ":#FFA;'>ANTONIO</span> ... LIMA <span class="
+                                    "'highlight' style='background:#FFA;'>OLIVEIRA"
+                                    "</span>, matrícula SIAPE nº 30772, ocupante do cargo"
+                                    " de Assistente Jurídico, Classe S, Padrão nº 71, de"
+                                    " 13 de abril de 2018, resolve: Nº 245 - Conceder "
+                                    "aposentadoria volu...",
+                                "date": "31/08/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "PORTARIA PRESI Nº 123, de 26 de agosto de 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/portaria-presi-n-123-de-26-de-agosto-de-2021-341642203",
+                                "abstract": "0007022-26.2021.6.07.8100, resolve: Designar,"
+                                " ad referendum do Tribunal, o Juiz de Direito ROQUE "
+                                "FABRÍCIO <span class='highlight' style='background:"
+                                "#FFA;'>ANTONIO</span> ... DE <span class='highlight' "
+                                "style='background:#FFA;'>OLIVEIRA</span> VIEL para "
+                                "exercer, a partir da publicação deste ato, a função de "
+                                "Juiz Substituto da 11ª Zona Eleitoral, ficando dispensada"
+                                " a Juíza de Direito Catarina de Macedo Nogueira Lima e "
+                                "Corrêa, a partir de 1º/08/2021. Des. HUMBERTO ADJUTO ULHÔA",
+                                "date": "30/08/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "PORTARIA DRF/NAT Nº 54, DE 24 DE AGOSTO DE 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/portaria-drf/nat-n-54-de-24-de-agosto-de-2021-341632367",
+                                "abstract": "Araújo Filho ENGENHARIA ELETRÔNICA Leandro "
+                                    "Mayron de Oliveira Pinto Leonardo de Barros e Silva "
+                                    "Edson"" <span class='highlight' style='background:"
+                                    "#FFA;'>Antônio</span> ... de <span class='highlight' "
+                                    "style='background:#FFA;'>Oliveira</span> Flávio Gentil"
+                                    " de Araújo Filho ENGENHARIA ELETRÔNICA Leandro Mayron"
+                                    " de Oliveira Pinto Leonardo ... de Barros e Silva "
+                                    "Edson <span class='highlight' style='background:"
+                                    "#FFA;'>Antônio</span> de <span class='highlight' "
+                                    "style='background:#FFA;'>Oliveira</span> Flávio "
+                                    "Gentil de Araújo Filho ENGENHARIA DOS MATERIAIS Gelsoneide",
+                                "date": "30/08/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "PORTARIA nº 1.664 - GAB/REI/IFPI, de 26 de agosto de 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/portaria-n-1.664-gab/rei/ifpi-de-26-de-agosto-de-2021-341621247",
+                                "abstract": "EDUCAÇÃO, CIÊNCIA E TECNOLOGIA DO PIAUÍ, no"
+                                    " uso de suas atribuições legais, resolve: Nomear o "
+                                    "servidor <span class='highlight' style='background"
+                                    ":#FFA;'>ANTÔNIO</span> ... LUÍS <span class="
+                                    "'highlight' style='background:#FFA;'>OLIVEIRA</span> "
+                                    "DOS REIS, Assistente em Administração, Nível de "
+                                    "Classificação D, Nível de Capacitaçãosto de 2021 O "
+                                    "REITOR DO INSTITUTO FEDERAL DE EDUCAÇÃO, CIÊNCIA E TECNOLOGI...",
+                                "date": "30/08/2021",
+                            },
+                            {
+                                "section": "Seção 3",
+                                "title": "AVISO DE LICITAÇÃO Tomada de Preço nº 1/2021",
+                                "href": "https://www.in.gov.br/web/dou/-/aviso-de-licitacao-tomada-de-preco-n-1/2021-341567981",
+                                "abstract": "Nacip Raydan-MG, 25 de agosto de 2021 Eduardo"
+                                    " <span class='highlight' style='background:#FFA;'>"
+                                    "Antônio</span> de <span class='highlight' style="
+                                    "'background:#FFA;'>Oliveira</span> Prefeitorna "
+                                    "público que realizar. Objeto: Contratação de empresa "
+                                    "especializada para Pavimentação em blocos sextavado "
+                                    "de concreto nas ruas Ataíde Moreira, Rua Peçanha, "
+                                    "Travessa Tiradentes e Ademar Alvarenga, Convênio n°. 88...",
+                                "date": "30/08/2021",
+                            },
+                            {
+                                "section": "Seção 3",
+                                "title": "EDITAL",
+                                "href": "https://www.in.gov.br/web/dou/-/edital-341218450",
+                                "abstract": "TAMARA SILVA DAIELLO ES-017002/O 5 CONTADOR "
+                                    "KLAUS XAVIER DE OLIVEIRA ES-011491/O 6 CONTADOR "
+                                    "MARCOS <span class='highlight' style='background:"
+                                    "#FFA;'>ANTÔNIO</span> ... DE <span class='highlight'"
+                                    " style='background:#FFA;'>OLIVEIRA</span> ES-008492/O"
+                                    " 7 CONTADOR EDUARDO TRESENA PORCHERA ES-021302/O 8 "
+                                    "CONTADOR JOSÉ JOCIMAR PINHEIROEDITAL RELAÇÃO DA "
+                                    "CHAPA HABILITADA A CONCORRER AO PLEITO DE RENOVAÇÃO DE ...",
+                                "date": "27/08/2021",
+                            },
+                            {
+                                "section": "Seção 2",
+                                "title": "RESOLUÇÃO ADMINISTRATIVA Nº 208, de 18 de agosto de 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/resolucao-administrativa-n-208-de-18-de-agosto-de-2021-341078554",
+                                "abstract": "Art. 1º Retificar a Resolução Administrativa "
+                                    "nº 74/2021/TRT11, referente à aposentadoria do "
+                                    "servidor <span class='highlight' style='background:"
+                                    "#FFA;'>ANTÔNIO</span> ... JOSÉ <span class="
+                                    "'highlight' style='background:#FFA;'>OLIVEIRA</span>"
+                                    " DA SILVA, para incluir a vantagem \"opção\" deferida"
+                                    " com base no art. 193 da Lei 8.112/90 ... a seguinte"
+                                    " redação: \"Art. 1º Conceder aposentadoria voluntária"
+                                    " com proventos integrais ao servidor <span class="
+                                    "'highlight' style='background:#FFA;'>ANTONIO</span>"
+                                    " ... JOSÉ <span class='highlight' style="
+                                    "'background:#FFA;'>OLIVEIRA</span> DA SILVA, "
+                                    "ocupante do cargo de Técnico Judiciário, Área"
+                                    " Administrativa, Sem Especialidade",
+                                "date": "27/08/2021",
+                            },
+                        ],
+                    },
+                    "dados abertos": {
+                        "single_department": [
+                            {
+                                "section": "Seção 1",
+                                "title": "RESOLUÇÃO CEPPDP/ME Nº 1, DE 31 DE AGOSTO DE 2021",
+                                "href": "https://www.in.gov.br/web/dou/-/resolucao-ceppdp/me-n-1-de-31-de-agosto-de-2021-341971457",
+                                "abstract": "revisados Dez/21-Jan/22 3 Produto 11 "
+                                    "Definição de diretrizes para elaboração e revisão do "
+                                    "Plano de <span class='highlight' style='background:"
+                                    "#FFA;'>Dados</span> ... <span class='highlight' "
+                                    "style='background:#FFA;'>Abertos</span> do ME, no"
+                                    " que diz respeito à divulgação de dados pessoais "
+                                    "Dez/21-Jan/22 3 Produto 12 Detalhamentova o Plano "
+                                    "de Ações Estruturantes e Entregas do Comitê "
+                                    "Estratégico de Priv...",
+                                "date": "01/09/2021",
+                            },
+                            {
+                                "section": "Seção 1",
+                                "title": "RETIFICAÇÃO",
+                                "href": "https://www.in.gov.br/web/dou/-/retificacao-341676133",
+                                "abstract": "de Textos no Sistema Braille Vigente Portaria"
+                                    " nº 380 de 27 de novembro de 2018 Publicar o Plano "
+                                    "de <span class='highlight' style='background:#FFA;'"
+                                    ">Dados</span> ... <span class='highlight' style="
+                                    "'background:#FFA;'>Abertos</span> - PDA Vigente "
+                                    "Portaria nº 440 de 28 de dezembro de 2018 Instituir"
+                                    " a Comissão para ElaboraçãoRETIFICAÇÃO A Portaria nº"
+                                    " 15, de 24 de agosto de 2021, publicada no Diário Ofic...",
+                                "date": "31/08/2021",
+                            },
+                        ],
+                    }
                 }
             },
             "header": "Teste Report",
@@ -328,7 +332,7 @@ def search_results() -> dict:
                 "date": "02/09/2021",
             },
         ],
-        "SILVA": [
+    "SILVA": [
             {
                 "section": "Seção 3",
                 "title": "EXTRATO DE CONTRATO",

--- a/tests/dag_generator_test.py
+++ b/tests/dag_generator_test.py
@@ -10,14 +10,15 @@ from airflow.timetables.datasets import DatasetOrTimeSchedule
 
 
 def test_repack_match(report_example):
-    match_dict = report_example[0]["result"]["single_group"]["antonio de oliveira"][0]
+    match_dict = report_example[0]["result"]["single_group"]["antonio de oliveira"]["single_department"][0]
     repacked_match = repack_match(
-        "Teste Report", "single_group", "antonio de oliveira", match_dict
+        "Teste Report", "single_group", "antonio de oliveira", "single_department", match_dict
     )
     assert repacked_match == (
         "Teste Report",
         "single_group",
         "antonio de oliveira",
+        "single_department",
         "Seção 3",
         match_dict["href"],
         match_dict["title"],
@@ -44,10 +45,10 @@ def test_convert_report_dict__returns_tuples(email_sender):
         assert isinstance(tpl, tuple)
 
 
-def test_convert_report_dict__returns_tuples_of_seven(email_sender):
+def test_convert_report_dict__returns_tuples_of_nine(email_sender):
     tuple_list = email_sender.convert_report_dict_to_tuple_list()
     for tpl in tuple_list:
-        assert len(tpl) == 8
+        assert len(tpl) == 9
 
 
 def test_convert_report_to_dataframe__rows_count(email_sender):

--- a/tests/discord_sender_test.py
+++ b/tests/discord_sender_test.py
@@ -94,44 +94,48 @@ def _send_report(specs):
         {
             "result": {
                 "single_group": {
-                    "lei de acesso à informação": [
-                        {
-                            "abstract": "GOV.BR/CURSO/563REGULAMENTAÇÃO "
-                            "DA __LEI DE ACESSO À INFORMAÇÃO__ "
-                            "NOS MUNICÍPIOSA LEI FEDERAL Nº "
-                            "12REGULAMENTAÇÃO DA LEI Nº 12.527/2011, "
-                            "A __LEI DE ACESSO À INFORMAÇÃO__ E, "
-                            "EM BREVE, SERÁ INCORPORADO AO CONTEÚDO",
-                            "date": "2023-01-31",
-                            "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3509502/2023-01-31/cd3fe0601a5fd9164b48b77bb14b2f0a78962766.pdf",
-                            "section": "QD - Edição " "ordinária ",
-                            "title": "Campinas/SP",
-                        }
-                    ],
-                    "lgpd": [
-                        {
-                            "abstract": "PESSOAISLEI GERAL DE PROTEÇÃO DE "
-                            "DADOS PESSOAIS - __LGPD__Nos termos "
-                            "dos Arts. 7º, 10º e 11º da Lei nº 13",
-                            "date": "2023-01-31",
-                            "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3518800/2023-01-31/958a384e1cc0cdb545a282e9bb55ea9aa74d4700.pdf",
-                            "section": "QD - Edição ordinária ",
-                            "title": "Guarulhos/SP",
-                        },
-                        {
-                            "abstract": "cumprimento da Lei Geral de Proteção "
-                            "de Dados Pessoal (__LGPD__ - Lei nº "
-                            "13.709, de 14 de agosto de 2018), "
-                            "alcançaLei 13.709/2018 – Lei Geral de "
-                            "Proteção de Dados (__LGPD__);VII -  "
-                            "atribuir no âmbito da “Segurança da "
-                            "Informação”",
-                            "date": "2023-01-31",
-                            "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3556206/2023-01-31/2d0f9088530a78c946ada20ec5558f40c5f92900",
-                            "section": "QD - Edição ordinária ",
-                            "title": "Valinhos/SP",
-                        },
-                    ],
+                    "lei de acesso à informação": {
+                        "single_department": [
+                            {
+                                "abstract": "GOV.BR/CURSO/563REGULAMENTAÇÃO "
+                                "DA __LEI DE ACESSO À INFORMAÇÃO__ "
+                                "NOS MUNICÍPIOSA LEI FEDERAL Nº "
+                                "12REGULAMENTAÇÃO DA LEI Nº 12.527/2011, "
+                                "A __LEI DE ACESSO À INFORMAÇÃO__ E, "
+                                "EM BREVE, SERÁ INCORPORADO AO CONTEÚDO",
+                                "date": "2023-01-31",
+                                "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3509502/2023-01-31/cd3fe0601a5fd9164b48b77bb14b2f0a78962766.pdf",
+                                "section": "QD - Edição " "ordinária ",
+                                "title": "Campinas/SP",
+                            }
+                        ],
+                    },
+                    "lgpd": {
+                        "single_department": [
+                            {
+                                "abstract": "PESSOAISLEI GERAL DE PROTEÇÃO DE "
+                                "DADOS PESSOAIS - __LGPD__Nos termos "
+                                "dos Arts. 7º, 10º e 11º da Lei nº 13",
+                                "date": "2023-01-31",
+                                "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3518800/2023-01-31/958a384e1cc0cdb545a282e9bb55ea9aa74d4700.pdf",
+                                "section": "QD - Edição ordinária ",
+                                "title": "Guarulhos/SP",
+                            },
+                            {
+                                "abstract": "cumprimento da Lei Geral de Proteção "
+                                "de Dados Pessoal (__LGPD__ - Lei nº "
+                                "13.709, de 14 de agosto de 2018), "
+                                "alcançaLei 13.709/2018 – Lei Geral de "
+                                "Proteção de Dados (__LGPD__);VII -  "
+                                "atribuir no âmbito da “Segurança da "
+                                "Informação”",
+                                "date": "2023-01-31",
+                                "href": "https://querido-diario.nyc3.cdn.digitaloceanspaces.com/3556206/2023-01-31/2d0f9088530a78c946ada20ec5558f40c5f92900",
+                                "section": "QD - Edição ordinária ",
+                                "title": "Valinhos/SP",
+                            },
+                        ],
+                    }
                 }
             },
             "header": "Test Discord Report",

--- a/tests/inlabs_hook_test.py
+++ b/tests/inlabs_hook_test.py
@@ -311,7 +311,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "date": "15/03/2024",
                         "id": 1,
                         "display_date_sortable": None,
-                        "hierarchyList": None,
+                        "hierarchyList": "Texto exemplo art_category",
                     }
                 ],
                 "Pellentesque": [
@@ -323,7 +323,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "date": "15/03/2024",
                         "id": 2,
                         "display_date_sortable": None,
-                        "hierarchyList": None,
+                        "hierarchyList": "Texto exemplo art_category",
                     }
                 ],
             },
@@ -372,7 +372,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "date": "15/03/2024",
                         "id": 1,
                         "display_date_sortable": None,
-                        "hierarchyList": None,
+                        "hierarchyList": "Texto exemplo art_category",
                     }
                 ],
             },
@@ -423,7 +423,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "date": "15/03/2024",
                         "id": 1,
                         "display_date_sortable": None,
-                        "hierarchyList": None,
+                        "hierarchyList": "Texto exemplo art_category",
                     }
                 ],
             },
@@ -503,7 +503,7 @@ def test_transform_search_results(
                         "date": "15/03/2024",
                         "id": 2,
                         "display_date_sortable": None,
-                        "hierarchyList": None,
+                        "hierarchyList": "Texto exemplo art_category",
                     }
                 ]
             },

--- a/tests/searchers_test.py
+++ b/tests/searchers_test.py
@@ -186,8 +186,7 @@ def test_cast_term_list__list_param(dou_searcher):
     pre_term_list = ["a", "b", "c"]
     assert tuple(dou_searcher._cast_term_list(pre_term_list)) == tuple(pre_term_list)
 
-
-def assert_grouped_result(grouped_result):
+def assert_grouped_term_result(grouped_result):
     assert "ATI" in grouped_result
     assert "SILVA" in grouped_result["ATI"]
     assert len(grouped_result["ATI"]["SILVA"]) == 4
@@ -195,18 +194,31 @@ def assert_grouped_result(grouped_result):
     assert "ANTONIO DE OLIVEIRA" in grouped_result["EPPGG"]
     assert len(grouped_result["EPPGG"]["ANTONIO DE OLIVEIRA"]) == 3
 
+def assert_grouped_term_dept_result(grouped_result):
+    assert "ATI" in grouped_result
+    assert "SILVA" in grouped_result["ATI"]
+    assert len(grouped_result["ATI"]["SILVA"]["single_department"]) == 4
+    assert "EPPGG" in grouped_result
+    assert "ANTONIO DE OLIVEIRA" in grouped_result["EPPGG"]
+    assert len(grouped_result["EPPGG"]["ANTONIO DE OLIVEIRA"]["single_department"]) == 3
+
 
 # TODO incluir teste com search_results vazio
 def test_group_by_term_group(dou_searcher, search_results, term_n_group):
     grouped_result = dou_searcher._group_by_term_group(search_results, term_n_group)
-    assert_grouped_result(grouped_result)
+    assert_grouped_term_result(grouped_result)
 
+def test_group_by_department(dou_searcher, search_results):
+    grouped_result = dou_searcher._group_by_department(search_results, None)
+    assert "single_department" in grouped_result["ANTONIO DE OLIVEIRA"]
+    assert "single_department" in grouped_result["SILVA"]
+    assert len(grouped_result["SILVA"]["single_department"]) == 4
 
 def test_group_results__sql_term_list_with_group(
     dou_searcher, search_results, term_n_group
 ):
     grouped_result = dou_searcher._group_results(search_results, term_n_group)
-    assert_grouped_result(grouped_result)
+    assert_grouped_term_dept_result(grouped_result)
 
 
 def test_group_results__sql_term_list_without_group(dou_searcher, search_results):


### PR DESCRIPTION
Agrupa os resultados por unidade no relatório.
- Cria nova função no searches para agrupar os resultados por unidade (department). Cria um nível a mais no dicionário de results para a unidade.
- Altera os senders de email, discord e slack para exibir a unidade quando especificada.
- Altera o INLABS_hook para utilizar o campo artcategory como valor de unidade.
- Atualiza os testes.
- Refatora o código de merge_results

Fix #121