### PR TITLE
Ajusta o código para utilizar XCom_pull de múltiplos Tasks IDs.

### DIFF
--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -343,18 +343,6 @@ class DouDigestDagGenerator:
 
         return search_dict
 
-    def _ensure_list_of_searches(self, specs: DAGConfig) -> list:
-        """Ensure that the search attribute is returned as a list,
-        whether it's originally a single element or a list."""
-
-        # is it a single search or a list of searchers?
-        if isinstance(specs.search, list):
-            searches = specs.search
-        else:
-            searches = [specs.search]
-
-        return searches
-
     def get_xcom_pull_tasks(self, num_searches, **context):
         """Retrieve XCom values from multiple tasks and append them to a new list.
         Function required for Airflow version 2.10.0 or later
@@ -455,7 +443,7 @@ class DouDigestDagGenerator:
 
             with TaskGroup(group_id="exec_searchs") as tg_exec_searchs:
 
-                searches = self._ensure_list_of_searches(specs=specs)
+                searches = specs.search
 
                 for counter, subsearch in enumerate(searches, 1):
 

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -8,7 +8,6 @@ TODO:
 [] - Definir sufixo do título do email a partir de configuração
 """
 
-import ast
 import logging
 import os
 import sys

--- a/src/notification/notifier.py
+++ b/src/notification/notifier.py
@@ -41,8 +41,6 @@ class Notifier:
             search_report (str): The report to be sent
             report_date (str): The date of the report
         """
-        # Convert to data structure after it's retrieved from xcom
-        search_report = ast.literal_eval(search_report)
 
         for sender in self.senders:
             sender.send_report(search_report, report_date)


### PR DESCRIPTION
A partir da versão 2.10 do Airflow foi detectado erro ao chamar múltiplos valores de tasks_ids no xcom_pull.

Código refatorado para fazer o loop entre cada task existente e receber via context e xcom_pull os valores em uma lista.

Fix #139 