### PR TITLE
Permitir busca no QD para um grupo de municípios

### DIFF
--- a/dag_confs/examples_and_tests/qd_list_territory_id_example.yaml
+++ b/dag_confs/examples_and_tests/qd_list_territory_id_example.yaml
@@ -1,0 +1,23 @@
+dag:
+  id: qd_list_territory_id_example
+  description: DAG de teste com múltiplos territory_id
+  schedule: 0 8 * * MON-FRI
+  search:
+    header: "Teste com múltiplos territory_id"
+    territory_id: 
+      - 3300100
+      - 3300159
+      - 3300209
+      - 3305703
+    sources:
+      - QD
+    terms:
+      - LGPD
+      - RIO DE JANEIRO
+    force_rematch: On
+    ignore_signature_match: On
+  report:
+    emails:
+      - destination@economia.gov.br
+    subject: "Teste do Ro-dou"
+    skip_null: False

--- a/docs/docs/como_funciona/parametros.md
+++ b/docs/docs/como_funciona/parametros.md
@@ -24,7 +24,7 @@ A página abaixo lista os parâmetros configuráveis nos arquivos YAML:
 - **is_exact_search**: Busca somente o termo exato. Valores: True ou False. Default: True.
 - **sources**: Fontes de pesquisa dos diários oficiais. Pode ser uma ou uma lista. Opções disponíveis: DOU, QD, INLABS.
 - **terms**: Lista de termos a serem buscados. Para o INLABS podem ser utilizados operadores avançados de busca.
-- **territory_id**: Identificador do id do município. Necessário para buscar no Querido Diário.
+- **territory_id**: Lista de identificadores do id do município. Necessário para buscar no Querido Diário.
 
 ## Parâmetros do Relatório (Report)
 - **attach_csv**: Anexar no email o resultado da pesquisa em CSV.

--- a/schemas/ro-dou.json
+++ b/schemas/ro-dou.json
@@ -63,9 +63,21 @@
                   }
                 },
                 "territory_id": {
-                  "type": "integer",
-                  "description": "Id do território no Querido Diário - QD"
+                  "oneOf": [
+                    {
+                      "type": "integer",
+                      "description": "Id do território no Querido Diário - QD",
+                    },
+                    {
+                      "type": "array",
+                      "description": "Lista de Id do território no Querido Diário - QD",
+                      "items": {
+                        "type": "integer"
+                      }
+                    }
+                  ]
                 },
+
                 "terms": {
                   "oneOf": [
                     {

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -60,7 +60,7 @@ class SearchConfig(BaseModel):
         description="Lista de fontes de dados para pesquisar (Querido Diário [QD], "
         "Diário Oficial da União [DOU], INLABS). Default: DOU.",
     )
-    territory_id: Optional[int] = Field(
+    territory_id: Optional[Union[int, List[int]]] = Field(
         default=None,
         description="ID do território no Querido Diário para filtragem "
         "baseada em localização",

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -365,7 +365,9 @@ class QDSearcher(BaseSearcher):
         payload = _build_query_payload(search_term, reference_date)
 
         if territory_id:
-            payload.append(("territory_ids", territory_id))
+            if isinstance(territory_id, int): territory_id = [territory_id]
+            for terr_id in territory_id:
+                payload.append(("territory_ids", terr_id))
 
         req_result = requests.get(self.API_BASE_URL, params=payload)
 

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -579,6 +579,53 @@ from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
                 },
             },
         ),
+        (
+            "qd_list_territory_id_example.yaml",
+            {
+                "id": "qd_list_territory_id_example",
+                "description": "DAG de teste com múltiplos territory_id",
+                "schedule": '0 8 * * MON-FRI',
+                "dataset": None,
+                "doc_md": None,
+                "tags": {"dou", "generated_dag"},
+                "owner": [],
+                "search": [
+                    {
+                        "terms": [
+                            "LGPD",
+                            "RIO DE JANEIRO",
+                        ],
+                        "header": "Teste com múltiplos territory_id",
+                        "sources": ["QD"],
+                        "sql": None,
+                        "conn_id": None,
+                        "territory_id": [3300100,3300159,3300209,3305703],
+                        "dou_sections": ["TODOS"],
+                        "search_date": "DIA",
+                        "field": "TUDO",
+                        "is_exact_search": True,
+                        "ignore_signature_match": True,
+                        "force_rematch": True,
+                        "full_text": False,
+                        "use_summary": False,
+                        "department": None,
+                    }
+                ],
+                "report": {
+                    "emails": ["destination@economia.gov.br"],
+                    "subject": "Teste do Ro-dou",
+                    "attach_csv": False,
+                    "discord_webhook": None,
+                    "slack_webhook": None,
+                    "skip_null": False,
+                    "hide_filters": False,
+                    "header_text": None,
+                    "footer_text": None,
+                    "no_results_found_text": "Nenhum dos termos pesquisados "
+                    "foi encontrado nesta consulta",
+                },
+            },
+        ),
     ],
 )
 def test_parse(filepath, result_tuple):

--- a/tests/qd_searcher_test.py
+++ b/tests/qd_searcher_test.py
@@ -79,3 +79,23 @@ def test_build_query_payload(pre_tags: str,
     ]
 
     assert payload == expected
+
+
+@pytest.mark.parametrize(
+    'territory_id, expected_payload',
+    [
+        (3300100, [('territory_ids', 3300100)]),
+        ([3300100, 3300159], [('territory_ids', 3300100), ('territory_ids', 3300159)]),
+    ]
+)
+def test_search_with_multiple_territory_ids(territory_id, expected_payload):
+    #searcher = QDSearcher()
+    payload = []
+
+    # Simula a lógica que foi alterada para suportar múltiplos IDs de território
+    if isinstance(territory_id, int):
+        territory_id = [territory_id]
+    for terr_id in territory_id:
+        payload.append(('territory_ids', terr_id))
+
+    assert payload == expected_payload


### PR DESCRIPTION
Alteração permite busca no querido diário para um grupo de municípios.
Alteração permite passar uma lista de territory_id no DAG;
Alteração não afeta DAGs exitentes que passam apenas um territory_id.