### PR TITLE
Adiciona novos parâmetros para o QD

### DIFF
--- a/dag_confs/examples_and_tests/qd_example.yaml
+++ b/dag_confs/examples_and_tests/qd_example.yaml
@@ -3,12 +3,17 @@ dag:
   description: DAG de teste
   search:
     sources:
-    - QD
+      - QD
     territory_id: 3106200
     terms:
-    - pandemia
-    - dados pessoais
-    - prefeitura
+      - pandemia
+      - prefeitura
+      - '"dados pessoais"'
+      - '"Software+valor"~100'
+      - '"\"Alimentação escolar\"+valor"~100'
+    is_exact_search: False
+    number_of_excerpts: 5
+    excerpt_size: 500
   report:
     emails:
       - destination@economia.gov.br

--- a/dag_confs/examples_and_tests/qd_list_territory_id_example.yaml
+++ b/dag_confs/examples_and_tests/qd_list_territory_id_example.yaml
@@ -14,8 +14,10 @@ dag:
     terms:
       - LGPD
       - RIO DE JANEIRO
-    force_rematch: On
-    ignore_signature_match: On
+      - DADOS PESSOAIS
+    is_exact_search: True
+    number_of_excerpts: 5
+    excerpt_size: 500
   report:
     emails:
       - destination@economia.gov.br

--- a/docs/docs/como_funciona/exemplos.md
+++ b/docs/docs/como_funciona/exemplos.md
@@ -134,9 +134,14 @@ dag:
     - QD
     territory_id: 3106200 # Belo Horizonte
     terms:
-    - pandemia
-    - dados pessoais
-    - prefeitura
+      - pandemia
+      - prefeitura
+      - '"dados pessoais"'
+      - '"Software+valor"~100'
+      - '"\"Alimentação escolar\"+valor"~100'
+    is_exact_search: False
+    number_of_excerpts: 5
+    excerpt_size: 500
   report:
     emails:
       - destination@gestao.gov.br

--- a/docs/docs/como_funciona/parametros.md
+++ b/docs/docs/como_funciona/parametros.md
@@ -27,6 +27,8 @@ A página abaixo lista os parâmetros configuráveis nos arquivos YAML:
 - **sources**: Fontes de pesquisa dos diários oficiais. Pode ser uma ou uma lista. Opções disponíveis: DOU, QD, INLABS.
 - **terms**: Lista de termos a serem buscados. Para o INLABS podem ser utilizados operadores avançados de busca.
 - **territory_id**: Lista de identificadores do id do município. Necessário para buscar no Querido Diário.
+- **excerpt_size**: Número máximo de caracteres exibidos no trecho onde o termo de busca foi localizado. (Funcionalidade disponível apenas no Querido Diário)
+- **number_of_excerpts**: Número máximo de ocorrências do termo de busca em uma mesma edição. (Funcionalidade disponível apenas no Querido Diário)
 
 ## Parâmetros do Relatório (Report)
 - **attach_csv**: Anexar no email o resultado da pesquisa em CSV.

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -277,6 +277,8 @@ class DouDigestDagGenerator:
         department: List[str],
         department_ignore: List[str],
         pubtype: List[str],
+        excerpt_size: Optional[int],
+        number_of_excerpts: Optional[int],
         **context,
     ) -> dict:
         """Performs the search in each source and merge the results"""
@@ -315,13 +317,10 @@ class DouDigestDagGenerator:
             qd_result = self.searchers["QD"].exec_search(
                 territory_id=territory_id,
                 term_list=term_list,
-                dou_sections=dou_sections,
-                search_date=search_date,
-                field=field,
                 is_exact_search=is_exact_search,
-                ignore_signature_match=ignore_signature_match,
-                force_rematch=force_rematch,
                 reference_date=get_trigger_date(context, local_time=True),
+                excerpt_size=excerpt_size,
+                number_of_excerpts=number_of_excerpts,
                 result_as_email=result_as_email,
             )
 
@@ -496,6 +495,8 @@ class DouDigestDagGenerator:
                             "department": subsearch.department,
                             "department_ignore": subsearch.department_ignore,
                             "pubtype": subsearch.pubtype,
+                            "excerpt_size": subsearch.excerpt_size,
+                            "number_of_excerpts": subsearch.number_of_excerpts,
                             "result_as_email": result_as_html(specs),
                         },
                     )

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -141,6 +141,16 @@ class SearchConfig(BaseModel):
     pubtype: Optional[List[str]] = Field(
         default=None, description="Lista de tipo de publicações para filtrar a pesquisa"
     )
+    excerpt_size: Optional[int] = Field(
+        default=None, 
+        description="Número máximo de caracteres exibidos no trecho onde o termo de busca foi localizado. "
+        "(Funcionalidade disponível apenas no Querido Diário)"
+    )
+    number_of_excerpts: Optional[int] = Field(
+        default=None, 
+        description="Número máximo de ocorrências do termo de busca em uma mesma edição. "
+        "(Funcionalidade disponível apenas no Querido Diário)"
+    )
 
 
 class ReportConfig(BaseModel):

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -608,6 +608,7 @@ from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
                         "terms": [
                             "LGPD",
                             "RIO DE JANEIRO",
+                            "DADOS PESSOAIS"
                         ],
                         "header": "Teste com múltiplos territory_id",
                         "sources": ["QD"],
@@ -618,12 +619,14 @@ from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
                         "search_date": "DIA",
                         "field": "TUDO",
                         "is_exact_search": True,
-                        "ignore_signature_match": True,
-                        "force_rematch": True,
+                        "ignore_signature_match": False,
+                        "force_rematch": False,
                         "full_text": False,
                         "use_summary": False,
                         "department": None,
                         "pubtype": None,
+                        "number_of_excerpts": 5,
+                        "excerpt_size": 500,
                     }
                 ],
                 "report": {


### PR DESCRIPTION
resolve #171

Adiciona parâmetros **excerpt_size** e **number_of_excerpts** para buscas no Querido Diário e passa a utilizar o parâmetro **is_exact_search** também nas consultas ao Querido Diário.

A possibilidade de não usar o termo exato permite a utilização de buscas avançadas no Querido Diário.

Também foi incluída lógica para alterar a quantidade de registros padrão nas respostas das requisições em que se utliza uma lista de territory_ids. 
Em uma busca, por exemplo, em todos os municípios de um Estado que possua mais de 100 cidades, o novo código retornará todos os resultados, mesmo que o resutado seja superior ao padrão de 100 registros.

A alteração ainda remove parâmetros não utilizados no método QDSearcher.exec_search