### PR TITLE
Create new parameter department_ignore

### DIFF
--- a/dag_confs/examples_and_tests/department_example.yaml
+++ b/dag_confs/examples_and_tests/department_example.yaml
@@ -2,8 +2,6 @@ dag:
   id: department_example
   description: DAG de teste (filtro por departamento)
   search:
-    sources:
-      - DOU
     terms:
       - dados abertos
     department:

--- a/dag_confs/examples_and_tests/department_example.yaml
+++ b/dag_confs/examples_and_tests/department_example.yaml
@@ -2,13 +2,15 @@ dag:
   id: department_example
   description: DAG de teste (filtro por departamento)
   search:
+    sources:
+      - DOU
     terms:
       - dados abertos
     department:
       - Ministério da Gestão e da Inovação em Serviços Públicos
       - Ministério da Defesa
-    departments_ignore:
-      - Ministério da Educação
+    department_ignore:
+      - Ministério da Defesa/Comando da Marinha
   report:
     emails:
       - destination@economia.gov.br

--- a/dag_confs/examples_and_tests/department_example.yaml
+++ b/dag_confs/examples_and_tests/department_example.yaml
@@ -7,6 +7,8 @@ dag:
     department:
       - Ministério da Gestão e da Inovação em Serviços Públicos
       - Ministério da Defesa
+    departments_ignore:
+      - Ministério da Educação
   report:
     emails:
       - destination@economia.gov.br

--- a/docs/docs/como_funciona/parametros.md
+++ b/docs/docs/como_funciona/parametros.md
@@ -15,6 +15,7 @@ A página abaixo lista os parâmetros configuráveis nos arquivos YAML:
 * **search**: Pode ser uma ou uma lista de pesquisas.
 - **date**: Intervalo de data para busca. Valores: DIA, SEMANA, MES, ANO. Default: DIA
 - **department**: Lista de unidades a serem filtradas na busca. O nome deve ser idêntico ao da publicação.
+- **department_ignore**: Lista de unidades e subordinadas a serem desconsideradas na busca. O nome deve ser idêntico ao da publicação.
 - **dou_sections**: Lista de seções do DOU onde a busca deverá ser realizada. Valores aceitos: SECAO_1, SECAO_2, SECAO_3, EDICAO_EXTRA, EDICAO_SUPLEMENTAR, TODOS.
 - **field**: Campos dos quais os termos devem ser pesquisados. Valores: TUDO, TITULO, CONTEUDO. Default: TUDO
 - **force_rematch**: Indica que a busca deve ser forçada, mesmo que já tenha sido feita anteriormente. Valores: True ou False.

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -171,7 +171,7 @@ class DouDigestDagGenerator:
                 doc_md += "\n" + "\n".join(f"- {str(item)}" for item in value) + "\n"
             else:
                 doc_md += "\n" + f"- {str(value)}\n" + "\n"
-                
+
         return doc_md
 
     @staticmethod
@@ -275,6 +275,7 @@ class DouDigestDagGenerator:
         use_summary: Optional[bool],
         result_as_email: Optional[bool],
         department: List[str],
+        department_ignore: List[str],
         pubtype: List[str],
         **context,
     ) -> dict:
@@ -301,6 +302,7 @@ class DouDigestDagGenerator:
                 dou_sections=dou_sections,
                 search_date=search_date,
                 department=department,
+                department_ignore=department_ignore,
                 ignore_signature_match=ignore_signature_match,
                 full_text=full_text,
                 use_summary=use_summary,
@@ -338,6 +340,7 @@ class DouDigestDagGenerator:
         search_dict["result"] = result
         search_dict["header"] = header
         search_dict["department"] = department
+        search_dict["department_ignore"] = department_ignore
         search_dict["pubtype"] = pubtype
 
         return search_dict
@@ -490,6 +493,7 @@ class DouDigestDagGenerator:
                             "full_text": subsearch.full_text,
                             "use_summary": subsearch.use_summary,
                             "department": subsearch.department,
+                            "department_ignore": subsearch.department_ignore,
                             "pubtype": subsearch.pubtype,
                             "result_as_email": result_as_html(specs),
                         },

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -293,6 +293,7 @@ class DouDigestDagGenerator:
                 ignore_signature_match=ignore_signature_match,
                 force_rematch=force_rematch,
                 department=department,
+                department_ignore=department_ignore,
                 pubtype=pubtype,
                 reference_date=get_trigger_date(context, local_time=True),
             )

--- a/src/hooks/dou_hook.py
+++ b/src/hooks/dou_hook.py
@@ -158,6 +158,7 @@ class DOUHook(BaseHook):
                     item["id"] = content["classPK"]
                     item["display_date_sortable"] = content["displayDateSortable"]
                     item["hierarchyList"] = content["hierarchyList"]
+                    item["hierarchyStr"] = content["hierarchyStr"]
                     item["arttype"] = content["artType"]
 
                     all_results.append(item)

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -92,7 +92,6 @@ class INLABSHook(BaseHook):
         )
         # Remove the words that suceeds the delimitator !
         filtered_text_terms = self._filter_text_terms(search_terms["texto"])
-
         return (
             self.TextDictHandler().transform_search_results(
                 all_results, filtered_text_terms, ignore_signature_match, full_text, use_summary
@@ -123,6 +122,7 @@ class INLABSHook(BaseHook):
             "name",
             "pubname",
             "artcategory",
+            "artcategory_ignore",
             "arttype",
             "identifica",
             "titulo",
@@ -193,6 +193,15 @@ class INLABSHook(BaseHook):
                             rf"dou_inlabs.unaccent({key}) ~* dou_inlabs.unaccent('\y{term}\y')")
 
                 key_conditions = " OR ".join(key_conditions)
+
+            elif key == 'artcategory_ignore':
+                key_conditions = " AND ".join(
+                    [
+                        rf"dou_inlabs.unaccent({key}) ~* dou_inlabs.unaccent('\y{value}\y')"
+                        for value in values
+                    ]
+                )
+
             else:
                 key_conditions = " OR ".join(
                     [
@@ -277,7 +286,8 @@ class INLABSHook(BaseHook):
             # `identifica` column is the publication title. If None
             # can be a table or other text content that is not inside
             # a publication.
-            df.dropna(subset=["identifica"], inplace=True)
+            # df.dropna(subset=["identifica"], inplace=True)
+
             df["pubname"] = df["pubname"].apply(self._rename_section)
             df["pubdate"] = df["pubdate"].dt.strftime("%d/%m/%Y")
             df["texto"] = df["texto"].apply(self._remove_html_tags, full_text=full_text)

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -197,7 +197,7 @@ class INLABSHook(BaseHook):
             elif key == 'artcategory_ignore':
                 key_conditions = " AND ".join(
                     [
-                        rf"dou_inlabs.unaccent({key}) ~* dou_inlabs.unaccent('\y{value}\y')"
+                        rf"dou_inlabs.unaccent(artcategory) !~* dou_inlabs.unaccent('^{value}')"
                         for value in values
                     ]
                 )

--- a/src/notification/email_sender.py
+++ b/src/notification/email_sender.py
@@ -92,7 +92,7 @@ class EmailSender(ISender):
                 blocks.append(f"<h1>{search['header']}</h1>")
 
             if not self.report_config.hide_filters:
-                if search["department"] or search["pubtype"]:
+                if search["department"] or search["department_ignore"] or search["pubtype"]:
                     blocks.append(
                         """<p class="secao-marker">Filtrando resultados somente para:</p>"""
                     )
@@ -102,6 +102,14 @@ class EmailSender(ISender):
                         for dpt in search["department"]:
                             blocks.append(f"<li><small>{dpt}</small></li>")
                         blocks.append("</ul>")
+
+                    if search["department_ignore"]:
+                        blocks.append("<small>Desconsiderar Unidades (e subordinadas):</small>")
+                        blocks.append("<ul>")
+                        for dpt in search["department_ignore"]:
+                            blocks.append(f"<li><small>{dpt}</small></li>")
+                        blocks.append("</ul>")
+
 
                     if search["pubtype"]:
                         blocks.append("<small>Tipos de publicações:</small>")

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -99,6 +99,9 @@ class SearchConfig(BaseModel):
     department: Optional[List[str]] = Field(
         default=None, description="Lista de departamentos para filtrar a pesquisa"
     )
+    department_ignore: Optional[List[str]] = Field(
+        default=None, description="Lista de departamentos a serem ignorados na pesquisa"
+    )
     terms: Union[List[str], FetchTermsConfig] = Field(
         description="Lista de termos de pesquisa ou uma forma de buscá-los"
     )

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -441,6 +441,7 @@ class INLABSSearcher(BaseSearcher):
         dou_sections: List[str],
         search_date: str,
         department: List[str],
+        department_ignore: List[str],
         ignore_signature_match: bool,
         full_text: bool,
         use_summary: bool,
@@ -459,6 +460,7 @@ class INLABSSearcher(BaseSearcher):
             search_date (str): Date interval filter.
                 search_date examples: DIA, SEMANA, MES, ANO
             department (List[str]): List of departments to filter the search.
+            department_ignore (List[str]): List of departments to be ignored in the search.
             ignore_signature_match (bool): Flag to ignore publication
                 signature content.
             full_text (bool): If trim result text content
@@ -474,7 +476,7 @@ class INLABSSearcher(BaseSearcher):
         inlabs_hook = INLABSHook()
         search_terms = self._prepare_search_terms(terms)
         search_terms = self._apply_filters(
-            search_terms, dou_sections, department, pubtype, reference_date, search_date
+            search_terms, dou_sections, department, department_ignore, pubtype, reference_date, search_date
         )
 
         search_results = inlabs_hook.search_text(
@@ -506,6 +508,7 @@ class INLABSSearcher(BaseSearcher):
         search_terms: Dict,
         sections: List[str],
         department: List[str],
+        department_ignore: List[str],
         pubtype: List[str],
         reference_date: datetime,
         search_date: str,
@@ -519,6 +522,8 @@ class INLABSSearcher(BaseSearcher):
             search_terms["pubname"] = self._parse_sections(sections)
         if department:
             search_terms["artcategory"] = department
+        if department_ignore:
+            search_terms["artcategory_ignore"] = department_ignore
         if pubtype:
             search_terms["arttype"] = pubtype
         publish_from = calculate_from_datetime(

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -324,7 +324,6 @@ class DOUSearcher(BaseSearcher):
                     results.remove(result)
             if department_ignore is not None:
                 if any(dpt in result["hierarchyStr"] for dpt in department_ignore):
-                    print (result)
                     results.remove(result)
     def _match_pubtype(self, results: list, pubtype: list) -> list:
         """Aplica o filtro nos resultados pela lista de tipos de publicações

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -155,6 +155,7 @@ class DOUSearcher(BaseSearcher):
         ignore_signature_match: bool,
         force_rematch: bool,
         department: List[str],
+        department_ignore: List[str],
         pubtype: List[str],
         reference_date: datetime,
     ):
@@ -168,6 +169,7 @@ class DOUSearcher(BaseSearcher):
             ignore_signature_match,
             force_rematch,
             department,
+            department_ignore,
             pubtype
         )
         group_results = self._group_results(search_results, term_list, department)
@@ -185,6 +187,7 @@ class DOUSearcher(BaseSearcher):
         ignore_signature_match,
         force_rematch,
         department,
+        department_ignore,
         pubtype
     ) -> dict:
         search_results = {}
@@ -211,8 +214,8 @@ class DOUSearcher(BaseSearcher):
                     if self._really_matched(search_term, r.get("abstract"))
                 ]
 
-            if department:
-                self._match_department(results, department)
+            if department or department_ignore:
+                self._match_department(results, department, department_ignore)
                 # results = [r for r in results if any(item in r.get('hierarchyList') for item in department)]
 
             if pubtype:
@@ -305,16 +308,24 @@ class DOUSearcher(BaseSearcher):
             )
         )
 
-    def _match_department(self, results: list, department: list) -> list:
+    def _match_department(self, results: list, department: list = None, department_ignore: list = None) -> list:
         """Aplica o filtro nos resultados pela lista de unidades informada
         no parâmetro 'department' do YAML
         """
-        logging.info("Applying filter for department list")
-        logging.info(department)
+        if department:
+            logging.info("Applying filter for department list")
+            logging.info(department)
+        if department_ignore:
+            logging.info("Applying filter for department_ignore list")
+            logging.info(department_ignore)
         for result in results[:]:
-            if not any(dpt in result["hierarchyList"] for dpt in department):
-                results.remove(result)
-
+            if department is not None:
+                if not any(dpt in result["hierarchyList"] for dpt in department):
+                    results.remove(result)
+            if department_ignore is not None:
+                if any(dpt in result["hierarchyStr"] for dpt in department_ignore):
+                    print (result)
+                    results.remove(result)
     def _match_pubtype(self, results: list, pubtype: list) -> list:
         """Aplica o filtro nos resultados pela lista de tipos de publicações
         no parâmetro 'pubtype' do YAML

--- a/tests/inlabs_hook_test.py
+++ b/tests/inlabs_hook_test.py
@@ -515,3 +515,23 @@ def test_ignore_signature(inlabs_hook, terms, df_in, dict_out):
         response=df_in, text_terms=terms, ignore_signature_match=True
     )
     assert r == dict_out
+
+
+
+@pytest.mark.parametrize(
+    "data_in, query_out",
+    [
+        (
+            {
+                "texto": ["term1", "term2"],
+                "pubname": ["DO1"],
+                "pubdate": ["2024-04-01", "2024-04-02"],
+                "artcategory": ["Ministério da Defesa"],
+                "artcategory_ignore": ["Ministério da Defesa/Comando da Marinha"],
+            },
+            "SELECT * FROM dou_inlabs.article_raw WHERE (pubdate BETWEEN '2024-04-01' AND '2024-04-02') AND (dou_inlabs.unaccent(texto) ~* dou_inlabs.unaccent('\\yterm1\\y') OR dou_inlabs.unaccent(texto) ~* dou_inlabs.unaccent('\\yterm2\\y')) AND (dou_inlabs.unaccent(pubname) ~* dou_inlabs.unaccent('\\yDO1\\y')) AND (dou_inlabs.unaccent(artcategory) ~* dou_inlabs.unaccent('\yMinistério da Defesa\y')) AND (dou_inlabs.unaccent(artcategory) !~* dou_inlabs.unaccent('^Ministério da Defesa/Comando da Marinha'))",
+        ),
+    ],
+)
+def test_generate_sql_with_department(inlabs_hook, data_in, query_out):
+    assert inlabs_hook._generate_sql(data_in)["select"] == query_out

--- a/tests/inlabs_searcher_test.py
+++ b/tests/inlabs_searcher_test.py
@@ -7,12 +7,13 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "search_terms, sections, department, pubtype, reference_date, search_date, filters_applyed",
+    "search_terms, sections, department, department_ignore, pubtype, reference_date, search_date, filters_applyed",
     [
         (
             {"texto": ["a", "b"]},
             ["SECAO_2"],
             ["Ministério"],
+            None,
             ["Edital"],
             datetime.now(),
             "DIA",
@@ -34,6 +35,7 @@ def test_apply_filters(
     search_terms,
     sections,
     department,
+    department_ignore,
     pubtype,
     reference_date,
     search_date,
@@ -41,7 +43,7 @@ def test_apply_filters(
 ):
     assert (
         inlabs_searcher._apply_filters(
-            search_terms, sections, department, pubtype, reference_date, search_date
+            search_terms, sections, department, department_ignore, pubtype, reference_date, search_date
         )
         == filters_applyed
     )

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -300,6 +300,9 @@ from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
                             "Ministério da Gestão e da Inovação em Serviços Públicos",
                             "Ministério da Defesa",
                         ],
+                        "department_ignore": [
+                            "Ministério da Defesa/Comando da Marinha",
+                        ],
                         "pubtype": None,
                     }
                 ],

--- a/tests/searchers_test.py
+++ b/tests/searchers_test.py
@@ -113,6 +113,7 @@ def test_really_matched(dou_searcher, search_term, abstract):
 
 def test_match_department(dou_searcher):
     department = ["Ministério da Defesa"]
+    department_ignore = ["Ministério da Defesa/Comando da Marinha"]
     results = [
         {
             "section": "Seção 3",
@@ -127,6 +128,7 @@ def test_match_department(dou_searcher):
                 "6ª Região Militar",
                 "28º Batalhão de Caçadores",
             ],
+            "hierarchyStr": "Ministério da Defesa/Comando do Exército/Comando Militar do Nordeste/6ª Região Militar/28º Batalhão de Caçadores",
         },
         {
             "section": "Seção 3",
@@ -135,9 +137,24 @@ def test_match_department(dou_searcher):
             "abstract": "ALESSANDRO GLAUCO DOS ANJOS DE VASCONCELOS - Secretário-Executivo Adjunto...",
             "date": "02/09/2021",
             "hierarchyList": ["Ministério dos Povos Indígenas"],
+            "hierarchyStr": "Ministério dos Povos Indígenas",
+        },
+        {
+            "section": "Seção 3",
+            "title": "EXTRATO DE COMPROMISSO",
+            "href": "https://www.in.gov.br/web/dou/-/extrato-de-compromisso-342504508",
+            "abstract": "ALESSANDRO GLAUCO DOS ANJOS DE VASCONCELOS - Secretário-Executivo Adjunto...",
+            "date": "02/09/2021",
+            "hierarchyList": [
+                "Ministério da Defesa",
+                "Comando da Marinha",
+                "Diretoria-Geral do Pessoal da Marinha",
+                "Diretoria de Ensino",
+            ],
+            "hierarchyStr": "Ministério da Defesa/Comando da Marinha",
         },
     ]
-    dou_searcher._match_department(results, department)
+    dou_searcher._match_department(results, department, department_ignore)
     assert len(results) == 1
 
 def test_match_pubtype(dou_searcher):


### PR DESCRIPTION
1. Criar um novo parâmetro chamado **department_ignore** com uma lista de departamentos que serão ignorados na busca. As unidades subordinadas também são ignoradas. Funciona para as fontes **DOU** e **INLabs**.
2. Criar um teste para gerar SQL com department no InlabsHook.
3. Atualizar a documentação com o novo parâmetro.

Fix #169 