### PR TITLE
feat: adiciona callbacks parametrizáveis para DAGs do Airflow

### DIFF
--- a/dag_confs/examples_and_tests/all_parameters_example.yaml
+++ b/dag_confs/examples_and_tests/all_parameters_example.yaml
@@ -8,6 +8,9 @@ dag:
     - pessoa 1
     - pessoa 2
   schedule: 0 8 * * MON-FRI
+  callbacks:
+    on_retry_callback: email_notification
+    on_failure_callback: slack_notification
   search:
     header: Pesquisa no DOU
     terms:

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -43,6 +43,7 @@ class YAMLParser:
         dag = self._try_get(dag_config_dict, "dag")
         dag_id = self._try_get(dag, "id")
         description = self._try_get(dag, "description")
+        callbacks = self._try_get(dag, "callbacks")
         report = self._try_get(dag, "report")
         search = self._try_get(dag, "search")
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -216,7 +216,16 @@ class ReportConfig(BaseModel):
         description="Texto a ser exibido quando não há resultados",
     )
 
-
+class CallBacksConfig(BaseModel):
+    """Represents the configuration of the callback functions in the YAML file."""
+    on_retry_callback: Optional[str] = Field(
+        default="email_notification",
+        description="Função que é executada quando uma task é reexecutada após uma falha",
+    )
+    on_failure_callback: Optional[str] = Field(
+        default="slack_notification",
+        description="Função que é executada quando uma task falha definitivamente (após esgotar todas as tentativas)",
+    )
 class DAGConfig(BaseModel):
     """Represents the DAG configuration in the YAML file."""
 
@@ -234,11 +243,23 @@ class DAGConfig(BaseModel):
     search: Union[List[SearchConfig], SearchConfig] = Field(
         description="Seção para definição da busca no Diário"
     )
+    callbacks: Union[CallBacksConfig, None] = Field(
+        default=None,
+        description="Seção para definição das funçãoes de callbacks"
+    )
     doc_md: Optional[str] = Field(default=None, description="description")
     report: ReportConfig = Field(
         description="Aceita: `slack`, `discord`, `emails`, `attach_csv`, "
         "`subject`, `skip_null`"
     )
+
+    @field_validator("callbacks")
+    def validate_callbacks(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return CallBacksConfig(**value)
+        return value
 
     @field_validator("search")
     @staticmethod

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -73,6 +73,10 @@ from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
                 "schedule": "0 8 * * MON-FRI",
                 "dataset": None,
                 "description": "DAG exemplo utilizando todos os demais parâmetros.",
+                "callbacks": {
+                    "on_retry_callback": "email_notification",
+                    "on_failure_callback": "slack_notification"
+                },
                 "doc_md": None,
                 "tags": {"dou", "generated_dag", "projeto_a", "departamento_x"},
                 "owner": ["pessoa 1", "pessoa 2"],
@@ -557,6 +561,7 @@ from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
                 "dataset": None,
                 "description": "DAG de teste",
                 "doc_md": None,
+                "callbacks": None,
                 "tags": {"dou", "generated_dag"},
                 "owner": [],
                 "search": [
@@ -600,7 +605,7 @@ from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
                 "description": "DAG de teste com múltiplos territory_id",
                 "schedule": '0 8 * * MON-FRI',
                 "dataset": None,
-                "doc_md": None,
+                "doc_md": None,                
                 "tags": {"dou", "generated_dag"},
                 "owner": [],
                 "search": [


### PR DESCRIPTION
 > implementa sistema de callbacks configuráveis via YAML para notificações
  customizadas

  ## Descrição

  implementa um sistema de callbacks parametrizáveis que permite configurar
  funções de notificação personalizadas para eventos de retry e falha nas DAGs do
  Airflow através de arquivos YAML.

  - adiciona nova seção `callbacks` no schema YAML com opções `on_retry_callback`
  e `on_failure_callback`
  - implementa handlers específicos para notificações por email (falhas) e Slack
  (retries)
  - atualiza o gerador de DAGs para usar callbacks dinâmicos baseados na
  configuração
  - adiciona validação e parsing da nova seção de callbacks
  - inclui exemplo de uso no arquivo de configuração de parâmetros

  ## Tipo de mudança

  Marque com um "x" o tipo de mudança que se aplica:

  - [ ] correção de bug
  - [x] nova funcionalidade
  - [ ] melhoria de código ou refatoração
  - [ ] atualização de documentação
  - [ ] outra (descreva abaixo)

  ## Checklist

  - [x] o código segue os padrões definidos no projeto
  - [x] os testes existentes não foram quebrados
  - [ ] a documentação foi atualizada (se aplicável)
  - [x] o ambiente de desenvolvimento foi testado com as mudanças
  - [ ] o pull request está vinculado a uma issue (se aplicável)

  ## Issue relacionada

  > #55 

## Revisor

> @edulauer 

  ## Considerações finais

  - os callbacks são opcionais e mantêm retrocompatibilidade
  - sistema extensível para adicionar novos tipos de notificação
  - handlers implementados para email (falhas definitivas) e Slack (retries)
  - configuração flexível via YAML permite diferentes estratégias por DAG
