### PR TITLE
doc: point community back to Github discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,5 @@ Para acessar a página de documentação do Ro-DOU, que contém detalhes sobre o
 
 O Ro-DOU é uma solução desenvolvida pela Secretaria de Gestão e Inovação do [Ministério da Gestão e da Inovação em Serviços Públicos](https://www.gov.br/gestao/pt-br).
 
-<p>
-  <a href="https://discord.gg/8R6bS5D2KN" target="_blank">
-    <img alt="Discord Invite" src="https://img.shields.io/badge/Discord-Entre%20no%20servidor-blue?style=for-the-badge&logo=discord" >
-  </a>
-</p>
-
-Ingresse em nosso [canal de comunidade](https://discord.gg/8R6bS5D2KN) para dúvidas, sugestões, contribuições e conversas em geral sobre o Ro-DOU.
+Participe do nosso [canal de comunidade](https://github.com/gestaogovbr/Ro-dou/discussions) para dúvidas, sugestões, contribuições e conversas em geral sobre o Ro-DOU.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -9,10 +9,4 @@ Neste site, você encontrará informações sobre como usar o Ro-DOU e quais fun
 
 O Ro-DOU é uma solução desenvolvida pela Secretaria de Gestão e Inovação do [Ministério da Gestão e da Inovação em Serviços Públicos](https://www.gov.br/gestao/pt-br).
 
-<p>
-  <a href="https://discord.gg/8R6bS5D2KN" target="_blank">
-    <img alt="Discord Invite" src="https://img.shields.io/badge/Discord-Entre%20no%20servidor-blue?style=for-the-badge&logo=discord" >
-  </a>
-</p>
-
-Ingresse em nosso [canal de comunidade](https://discord.gg/8R6bS5D2KN) para dúvidas, sugestões, contribuições e conversas em geral sobre o Ro-DOU.
+Participe do nosso [canal de comunidade](https://github.com/gestaogovbr/Ro-dou/discussions) para dúvidas, sugestões, contribuições e conversas em geral sobre o Ro-DOU.

--- a/docs/docs/outros/contato.md
+++ b/docs/docs/outros/contato.md
@@ -7,10 +7,4 @@ Dúvidas, sugestões e demais comentários sobre o Ro-DOU podem ser enviados ao 
 
 Interações de caráter técnico e sugestões de melhoria no código-fonte e nas funcionalidades do Ro-DOU podem ser enviadas diretamente via GitHub, por meio da abertura de `issues`: <https://github.com/gestaogovbr/Ro-dou>.
 
-<p>
-  <a href="https://discord.gg/8R6bS5D2KN" target="_blank">
-    <img alt="Discord Invite" src="https://img.shields.io/badge/Discord-Entre%20no%20servidor-blue?style=for-the-badge&logo=discord" >
-  </a>
-</p>
-
-Ingresse em nosso [canal de comunidade](https://discord.gg/8R6bS5D2KN) para dúvidas, sugestões, contribuições e conversas em geral sobre o Ro-DOU.
+Participe do nosso [canal de comunidade](https://github.com/gestaogovbr/Ro-dou/discussions) para dúvidas, sugestões, contribuições e conversas em geral sobre o Ro-DOU.


### PR DESCRIPTION
Fix #230 

Direciona o canal de discussões, dúvidas e perguntas de volta ao [Github Discussions](https://github.com/gestaogovbr/Ro-dou/discussions), em vez do Discord, para simplificar e manter tudo em uma só plataforma. Não faz sentido exigir que as pessoas criem um outro login diferente só para poder participar.