### PR TITLE
docs: adiciona badge do GitHub e customiza template ReadTheDocs

### DIFF
--- a/docs/docs/como_utilizar/instalacao.md
+++ b/docs/docs/como_utilizar/instalacao.md
@@ -13,7 +13,8 @@
 * 2Gb de espaço em disco
 * Sistema operacional Linux ou Windows com WSL
 
-O código-fonte está disponibilizado no [perfil do GitHub do Ministério da Gestão e da Inovação em Serviços Públicos](https://github.com/gestaogovbr/Ro-dou).
+O código-fonte está disponibilizado no <a href="https://github.com/gestaogovbr/Ro-dou"><img src="https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" style="vertical-align: middle; display: inline-block;"></a> perfil do GitHub do Ministério da Gestão e da Inovação em Serviços Públicos.
+
 
 Neste título, fornecemos abaixo uma configuração demonstrativa para que você possa executar o Ro-DOU no seu computador.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,131 +1,147 @@
 <!DOCTYPE html>
-<html class="writer-html5" lang="en" >
+<html class="writer-html5" lang="en">
+
 <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="description" content="None" />
-      <link rel="shortcut icon" href="img/favicon.ico" />
-    <title>Ro-DOU - ferramenta de clipping dos diários oficiais</title>
-    <link rel="stylesheet" href="css/theme.css" />
-    <link rel="stylesheet" href="css/theme_extra.css" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" />
-    
-      <script>
-        // Current page data
-        var mkdocs_page_name = "P\u00e1gina Inicial";
-        var mkdocs_page_input_path = "index.md";
-        var mkdocs_page_url = null;
-      </script>
-    
-    <!--[if lt IE 9]>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="None" />
+  <link rel="shortcut icon" href="img/favicon.ico" />
+  <title>Ro-DOU - ferramenta de clipping dos diários oficiais</title>
+  <link rel="stylesheet" href="css/theme.css" />
+  <link rel="stylesheet" href="css/theme_extra.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" />
+
+  <script>
+    // Current page data
+    var mkdocs_page_name = "P\u00e1gina Inicial";
+    var mkdocs_page_input_path = "index.md";
+    var mkdocs_page_url = null;
+  </script>
+
+  <!--[if lt IE 9]>
       <script src="js/html5shiv.min.js"></script>
     <![endif]-->
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
-      <script>hljs.highlightAll();</script> 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
 </head>
 
 <body class="wy-body-for-nav" role="document">
 
   <div class="wy-grid-for-nav">
     <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
-    <div class="wy-side-scroll">
-      <div class="wy-side-nav-search">
-          <a href="." class="icon icon-home"> Ro-DOU - ferramenta de clipping dos diários oficiais
-        </a><div role="search">
-  <form id ="rtd-search-form" class="wy-form" action="./search.html" method="get">
-      <input type="text" name="q" placeholder="Search docs" aria-label="Search docs" title="Type search term here" />
-  </form>
-</div>
-      </div>
+      <div class="wy-side-scroll">
+        <div class="wy-side-nav-search">
+          <a href="." class="icon icon-home"> Ro-DOU - ferramenta de clipping dos diários oficiais</a>         
+          <div role="search">
+            <form id="rtd-search-form" class="wy-form" action="./search.html" method="get">
+              <input type="text" name="q" placeholder="Search docs" aria-label="Search docs"
+                title="Type search term here" />
+            </form>
+          </div>                      
+        </div>
 
-      <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
+        <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
+          <ul class="current">
+            <li class="toctree-l1 current"><a class="reference internal current" href="#">Página Inicial</a>
               <ul class="current">
-                <li class="toctree-l1 current"><a class="reference internal current" href="#">Página Inicial</a>
-    <ul class="current">
-    </ul>
-                </li>
               </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="rodou/">O que é Ro-DOU?</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="utilizacao/">Como utilizar</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="funcionamento/">Como funciona</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="contribuicoes/">Como contribuir</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="faq/">FAQ</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="midias/">Oficinas e mídias</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="links/">Links relevantes</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="contato/">Contato</a>
-                </li>
-              </ul>
-              <ul>
-                <li class="toctree-l1"><a class="reference internal" href="changelog/">Changelog</a>
-                </li>
-              </ul>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="rodou/">O que é Ro-DOU?</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="utilizacao/">Como utilizar</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="funcionamento/">Como funciona</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="contribuicoes/">Como contribuir</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="faq/">FAQ</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="midias/">Oficinas e mídias</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="links/">Links relevantes</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="contato/">Contato</a>
+            </li>
+          </ul>
+          <ul>
+            <li class="toctree-l1"><a class="reference internal" href="changelog/">Changelog</a>
+            </li>
+          </ul>
+        </div>
       </div>
-    </div>
     </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
       <nav class="wy-nav-top" role="navigation" aria-label="Mobile navigation menu">
-          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-          <a href=".">Ro-DOU - ferramenta de clipping dos diários oficiais</a>
-        
+        <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+        <a href=".">Ro-DOU - ferramenta de clipping dos diários oficiais</a>
+
       </nav>
       <div class="wy-nav-content">
-        <div class="rst-content"><div role="navigation" aria-label="breadcrumbs navigation">
-  <ul class="wy-breadcrumbs">
-    <li><a href="." class="icon icon-home" aria-label="Docs"></a></li>
-      <li class="breadcrumb-item active">Página Inicial</li>
-    <li class="wy-breadcrumbs-aside">
-    </li>
-  </ul>
-  <hr/>
-</div>
+        <div class="rst-content">
+          <div role="navigation" aria-label="breadcrumbs navigation">
+            <ul class="wy-breadcrumbs">
+              <li><a href="." class="icon icon-home" aria-label="Docs"></a></li>
+              <li class="breadcrumb-item active">Página Inicial</li>
+              <li class="wy-breadcrumbs-aside">
+              </li>
+            </ul>
+            <hr />
+          </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
             <div class="section" itemprop="articleBody">
-              
-                <h1 id="ro-dou">Ro-DOU</h1>
-<p><a href="https://github.com/gestaogovbr/Ro-dou/actions/workflows/ci-tests.yml"><img alt="CI Tests" src="https://github.com/gestaogovbr/Ro-dou/actions/workflows/ci-tests.yml/badge.svg" /></a></p>
-<p>O Ro-DOU é uma ferramenta que efetua um <em>clipping</em> do Diário
-Oficial da União (<a href="https://www.gov.br/imprensanacional/pt-br">D.O.U.</a>) e dos Diários Oficiais de municípios, por meio do <a href="https://queridodiario.ok.org.br/">Querido Diário</a>. O Ro-DOU permite o recebimento de notificações (via e-mail, Slack, Discord ou outros) de todas as publicações que contenham as <strong>palavras-chaves</strong> que você definir.</p>
-<p>Neste site, você encontrará informações sobre como usar o Ro-DOU e quais funcionalidades ele proporciona, além de outras informações sobre como contribuir para melhorar a ferramenta e como contatar o MGI.</p>
-<p>O Ro-DOU é uma solução desenvolvida pela Secretaria de Gestão e Inovação do <a href="https://www.gov.br/gestao/pt-br">Ministério da Gestão e da Inovação em Serviços Públicos</a>.</p>
-              
+
+              <h1 id="ro-dou">Ro-DOU</h1>
+              <p><a href="https://github.com/gestaogovbr/Ro-dou/actions/workflows/ci-tests.yml"><img alt="CI Tests"
+                    src="https://github.com/gestaogovbr/Ro-dou/actions/workflows/ci-tests.yml/badge.svg" /></a></p>
+              <p>O Ro-DOU é uma ferramenta que efetua um <em>clipping</em> do Diário
+                Oficial da União (<a href="https://www.gov.br/imprensanacional/pt-br">D.O.U.</a>) e dos Diários Oficiais
+                de municípios, por meio do <a href="https://queridodiario.ok.org.br/">Querido Diário</a>. O Ro-DOU
+                permite o recebimento de notificações (via e-mail, Slack, Discord ou outros) de todas as publicações que
+                contenham as <strong>palavras-chaves</strong> que você definir.</p>
+              <p>Neste site, você encontrará informações sobre como usar o Ro-DOU e quais funcionalidades ele
+                proporciona, além de outras informações sobre como contribuir para melhorar a ferramenta e como contatar
+                o MGI.</p>
+              <p>O Ro-DOU é uma solução desenvolvida pela Secretaria de Gestão e Inovação do <a
+                  href="https://www.gov.br/gestao/pt-br">Ministério da Gestão e da Inovação em Serviços Públicos</a>.
+              </p>
+
             </div>
-          </div><footer>
-    <div class="rst-footer-buttons" role="navigation" aria-label="Footer Navigation">
-        <a href="rodou/" class="btn btn-neutral float-right" title="O que é Ro-DOU?">Next <span class="icon icon-circle-arrow-right"></span></a>
-    </div>
+          </div>
+          <footer>
+            <div class="rst-footer-buttons" role="navigation" aria-label="Footer Navigation">
+              <a href="rodou/" class="btn btn-neutral float-right" title="O que é Ro-DOU?">Next <span
+                  class="icon icon-circle-arrow-right"></span></a>
+            </div>
 
-  <hr/>
+            <hr />
 
-  <div role="contentinfo">
-    <!-- Copyright etc -->
-  </div>
+            <div role="contentinfo">
+              <!-- Copyright etc -->
+            </div>
 
-  Built with <a href="https://www.mkdocs.org/">MkDocs</a> using a <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
-</footer>
-          
+            Built with <a href="https://www.mkdocs.org/">MkDocs</a> using a <a
+              href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a> provided by <a
+              href="https://readthedocs.org">Read the Docs</a>.
+          </footer>
+
         </div>
       </div>
 
@@ -134,26 +150,27 @@ Oficial da União (<a href="https://www.gov.br/imprensanacional/pt-br">D.O.U.</a
   </div>
 
   <div class="rst-versions" role="note" aria-label="Versions">
-  <span class="rst-current-version" data-toggle="rst-current-version">
-    
-    
-    
+    <span class="rst-current-version" data-toggle="rst-current-version">
+
+
+
       <span><a href="rodou/" style="color: #fcfcfc">Next &raquo;</a></span>
-    
-  </span>
-</div>
-    <script src="js/jquery-3.6.0.min.js"></script>
-    <script>var base_url = ".";</script>
-    <script src="js/theme_extra.js"></script>
-    <script src="js/theme.js"></script>
-      <script src="search/main.js"></script>
-    <script>
-        jQuery(function () {
-            SphinxRtdTheme.Navigation.enable(true);
-        });
-    </script>
+
+    </span>
+  </div>
+  <script src="js/jquery-3.6.0.min.js"></script>
+  <script>var base_url = ".";</script>
+  <script src="js/theme_extra.js"></script>
+  <script src="js/theme.js"></script>
+  <script src="search/main.js"></script>
+  <script>
+    jQuery(function () {
+      SphinxRtdTheme.Navigation.enable(true);
+    });
+  </script>
 
 </body>
+
 </html>
 
 <!--

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,6 +30,8 @@ nav:
     - Contato: outros/contato.md
   - CHANGELOG:
     - Changelog: changelog/changelog.md
-
+    
 theme:
-  name: 'readthedocs'
+  name: readthedocs
+  custom_dir: overrides
+  

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <style>
+    .github-icon {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      z-index: 1000;
+      background: #333;
+      color: white;
+      padding: 10px;
+      border-radius: 50%;
+      text-decoration: none;
+      font-size: 20px;
+      transition: background 0.3s;
+    }
+    .github-icon:hover {
+      background: #555;
+      color: white;
+      text-decoration: none;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+  <a href="https://github.com/gestaogovbr/Ro-dou" class="github-icon" target="_blank" title="GitHub Repository">
+    <i class="fab fa-github"></i>
+  </a>
+{% endblock %}


### PR DESCRIPTION
  - Adiciona badge estilizado do GitHub em toda as páginas
  - Configura template customizado para ReadTheDocs com diretório overrides
  - Melhora formatação do HTML da página inicial
  - Atualiza configuração do MkDocs para suportar customizações