### PR TITLE
Fix case-insensitive sorting in _find_matches

### DIFF
--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -411,7 +411,7 @@ class INLABSHook(BaseHook):
                 )
             ]
 
-            return ", ".join(sorted(set(matches)))
+            return ", ".join(sorted(set(matches), key=str.lower))
 
         @staticmethod
         def _normalize(text: str) -> str:


### PR DESCRIPTION
This PR fixes the case-sensitive sorting issue in `_find_matches` so that matches are sorted alphabetically.

This addresses issue #42 