### PR TITLE
refactor: Improve pagination robustness by removing implicit dependency on `item` creation order

### DIFF
--- a/src/hooks/dou_hook.py
+++ b/src/hooks/dou_hook.py
@@ -139,19 +139,20 @@ class DOUHook(BaseHook):
         logging.info("Total pages: %s", number_pages)
 
         all_results = []
+        last_item = None
 
         # Loop for each page of result
         for page_num in range(number_pages):
             logging.info("Searching in page %s", str(page_num + 1))
 
             # If there is more than one page add extra payload params and reload the page
-            if page_num > 0:
+            if page_num > 0 and last_item:
                 # The id is needed for pagination to work because it requires
                 # passing the last id from the previous item page in request URL
                 # Delta is the number of records per page. By now is restricted up to 20.
                 payload.update({
-                    "id": item["id"],
-                    "displayDate": item["display_date_sortable"],
+                    "id": last_item["id"],
+                    "displayDate": last_item["display_date_sortable"],
                     # "delta": 20,
                     "newPage": page_num + 1,
                     "currentPage": page_num,
@@ -179,18 +180,20 @@ class DOUHook(BaseHook):
 
             if search_results:
                 for content in search_results:
-                    item = {}
-                    item["section"] = content["pubName"].lower()
-                    item["title"] = content["title"]
-                    item["href"] = self.IN_WEB_BASE_URL + content["urlTitle"]
-                    item["abstract"] = content["content"]
-                    item["date"] = content["pubDate"]
-                    item["id"] = content["classPK"]
-                    item["display_date_sortable"] = content["displayDateSortable"]
-                    item["hierarchyList"] = content["hierarchyList"]
-                    item["hierarchyStr"] = content["hierarchyStr"]
-                    item["arttype"] = content["artType"]
+                    item = {
+                        "section": content["pubName"].lower(),
+                        "title": content["title"],
+                        "href": self.IN_WEB_BASE_URL + content["urlTitle"],
+                        "abstract": content["content"],
+                        "date": content["pubDate"],
+                        "id": content["classPK"],
+                        "display_date_sortable": content["displayDateSortable"],
+                        "hierarchyList": content["hierarchyList"],
+                        "hierarchyStr": content["hierarchyStr"],
+                        "arttype": content["artType"],
+                        }
 
                     all_results.append(item)
+                    last_item = item
 
         return all_results


### PR DESCRIPTION
## Contexto

O código atual de paginação depende da variável `item` ser criada durante a
primeira iteração (page_num == 0). Isso funciona apenas porque a primeira página
das buscas do DOU normalmente contém resultados.

No entanto, essa dependência implícita gera dois problemas:

### 1. Resultados vazios na primeira página quebram o loop

Se a primeira página vier vazia — algo que ocorre ocasionalmente devido a
inconsistências da API — o loop interno (`for content in search_results`) não
executa e `item` nunca é definido. Na iteração seguinte (`page_num == 1`),
`item` é referenciado antes de ser atribuído, causando:

`UnboundLocalError: local variable 'item' referenced before assignment`

### 2. Uso de variável definida em loop interno dentro do loop externo é considerado má prática

Essa abordagem cria um acoplamento frágil entre a ordem das iterações e a
existência da variável. Além de não ser idiomático em Python, torna o código
sensível a qualquer pequena mudança na API, especialmente em bugs ou páginas
sem resultados.

## Solução

Introduzida uma variável `last_item`, inicializada antes do loop de páginas.
Ela é atualizada a cada item processado e utilizada apenas quando disponível.

Isso mantém o comportamento atual intacto e melhora a robustez da paginação,
removendo a dependência implícita entre loops.

## Impacto

- Nenhuma alteração de comportamento externo
- Torna o código estável mesmo com páginas vazias
- Simplifica a leitura e manutenção
- Evita erros silenciosos caso a API altere a estrutura

