### PR TITLE
fix: Corrige compatibilidade da seção de filtros no Outlook

### DIFF
--- a/src/notification/templates/dou_template.html
+++ b/src/notification/templates/dou_template.html
@@ -63,11 +63,10 @@
             max-width: 1200px;
             margin: 0 auto 20px auto;
             background-color: white;
-            border-radius: 8px;
             padding: 15px;
             margin-bottom: 10px;
             border-left: 4px solid #06acff;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            border: 1px solid #e9ecef;
         }
 
         .filter-title {
@@ -85,24 +84,17 @@
         }
 
         .filter-list {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-            gap: 5px;
             margin: 0;
             padding: 0;
+            padding-left: 20px;
+            list-style-type: disc;
         }
 
         .filter-list li {
-            list-style: none;
             padding: 3px 0;
             font-size: 14px;
             color: #666;
-        }
-
-        .filter-list li::before {
-            content: "• ";
-            color: #06acff;
-            font-weight: bold;
+            margin-left: 15px;
         }
 
         .results-section {


### PR DESCRIPTION
# Corrige compatibilidade da seção de filtros no Outlook

## Descrição

Esta PR corrige um problema onde a seção de filtros não estava aparecendo corretamente em clientes de email Outlook. O Outlook (especialmente versões desktop do Windows) usa o motor de renderização do Word, que tem suporte limitado a CSS moderno.

As seguintes alterações foram implementadas:

- Remove propriedade CSS Grid (`display: grid`) não suportada pelo Outlook
- Remove `border-radius` e `box-shadow` (suporte limitado no Outlook)
- Simplifica estilização de listas usando `list-style-type` padrão
- Substitui pseudo-elemento `::before` customizado por bullets nativos de lista
- Adiciona borda simples (`border: 1px solid`) no lugar de `box-shadow`

## Tipo de mudança

- [x] correção de bug  
- [ ] nova funcionalidade  
- [ ] melhoria de código ou refatoração  
- [ ] atualização de documentação  
- [ ] outra (descreva abaixo)

## Checklist

- [x] o código segue os padrões definidos no projeto  
- [x] os testes existentes não foram quebrados  
- [ ] a documentação foi atualizada (se aplicável)  
- [x] o ambiente de desenvolvimento foi testado com as mudanças  
- [ ] o pull request está vinculado a uma issue (se aplicável)

## Issue relacionada

## Revisor
@edulauer

N/A - correção identificada pelo usuário durante uso do sistema

## Considerações finais

### Contexto técnico
O Outlook usa o mecanismo de renderização do Word em vez de um navegador web padrão, resultando em suporte limitado para:
- CSS Grid e Flexbox
- Propriedades modernas como `border-radius`, `box-shadow`, `gap`
- Pseudo-elementos complexos

### Teste recomendado
Para validar completamente a correção, recomenda-se:
1. Enviar um email de teste para uma conta Outlook (preferencialmente Outlook Desktop para Windows)
2. Verificar se a seção de filtros aparece corretamente formatada
3. Confirmar que os itens da lista estão visíveis e bem formatados

### Mudanças visuais
As alterações mantêm a aparência visual em navegadores modernos, mas garantem que a seção seja renderizada corretamente no Outlook:
- A lista de filtros agora usa bullets padrão em vez de bullets customizados azuis
- Borda sólida em vez de sombra (mais leve visualmente, mas funcional)
- Layout de lista vertical simples em vez de grid (mais compatível)