### PR TITLE
Fix/highlight terms accent insensitive

### DIFF
--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -472,9 +472,16 @@ class INLABSHook(BaseHook):
                 else ""
             )
 
-        @staticmethod
-        def _highlight_terms(terms: list, text: str) -> str:
+        def _highlight_terms(self, terms: list, text: str) -> str:
             """Wrap `terms` values in `text` with `<%%>` and `</%%>`.
+
+            Matching is done against a normalized (accent-stripped) version of
+            the text so that a search term like "Flavia" also highlights
+            "Flávia" in the original text.  Positions found in the normalized
+            text are mapped back to the original text — this is safe because
+            ``_normalize`` maps each source character to exactly one ASCII
+            character (accented Latin letters, cedillas, etc.).  If the lengths
+            diverge for any reason, the method falls back to direct matching.
 
             Args:
                 terms (list): List of terms to be wrapped on text.
@@ -486,15 +493,27 @@ class INLABSHook(BaseHook):
                     and `</%%>`.
             """
 
-            escaped_terms = [re.escape(term) for term in terms if term]
+            escaped_terms = [re.escape(self._normalize(term)) for term in terms if term]
             if not escaped_terms:
                 return text
             pattern = rf"\b({'|'.join(escaped_terms)})\b"
-            highlighted_text = re.sub(
-                pattern, r"<%%>\1</%%>", text, flags=re.IGNORECASE
-            )
 
-            return highlighted_text
+            normalized_text = self._normalize(text)
+
+            if len(normalized_text) != len(text):
+                # direct case-insensitive match on original text
+                direct_pattern = rf"\b({'|'.join(re.escape(t) for t in terms if t)})\b"
+                return re.sub(direct_pattern, r"<%%>\1</%%>", text, flags=re.IGNORECASE)
+
+            result = []
+            last_end = 0
+            for m in re.finditer(pattern, normalized_text, flags=re.IGNORECASE):
+                result.append(text[last_end : m.start()])
+                result.append(f"<%%>{text[m.start() : m.end()]}</%%>")
+                last_end = m.end()
+            result.append(text[last_end:])
+
+            return "".join(result)
 
         @staticmethod
         def _visible_len(text: str) -> int:

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -337,7 +337,14 @@ class INLABSHook(BaseHook):
             df["identifica"] = df["identifica"].str.strip().str.upper()
 
             if any(text_terms):
-                df["matches"] = df["texto"].apply(self._find_matches, keys=text_terms)
+                # df["matches"] = df["texto"].apply(self._find_matches, keys=text_terms)
+                df["matches"] = df.apply(
+                    lambda row: self._find_matches(
+                        row["texto"] + " " + row["identifica"],
+                        keys=text_terms,
+                    ),
+                    axis=1,
+                )
                 df["matches_assina"] = df.apply(
                     lambda row: self._normalize(row["matches"])
                     in self._normalize(row["assina"]),
@@ -347,6 +354,13 @@ class INLABSHook(BaseHook):
                     lambda row: self._highlight_terms(
                         [t for t in row["matches"].split(", ") if t],
                         row["texto"],
+                    ),
+                    axis=1,
+                )
+                df["identifica"] = df.apply(
+                    lambda row: self._highlight_terms(
+                        [t for t in row["matches"].split(", ") if t],
+                        row["identifica"],
                     ),
                     axis=1,
                 )
@@ -476,8 +490,8 @@ class INLABSHook(BaseHook):
             """Wrap `terms` values in `text` with `<%%>` and `</%%>`.
 
             Matching is done against a normalized (accent-stripped) version of
-            the text so that a search term like "Flavia" also highlights
-            "Flávia" in the original text.  Positions found in the normalized
+            the text so that a search term like "Ministerio" also highlights
+            "Ministério" in the original text.  Positions found in the normalized
             text are mapped back to the original text — this is safe because
             ``_normalize`` maps each source character to exactly one ASCII
             character (accented Latin letters, cedillas, etc.).  If the lengths

--- a/src/notification/isender.py
+++ b/src/notification/isender.py
@@ -56,6 +56,11 @@ class ISender(ABC):
                             .replace("<%%>", open_tag)
                             .replace("</%%>", close_tag)
                         )
+                        item["title"] = (
+                            item["title"]
+                            .replace("<%%>", open_tag)
+                            .replace("</%%>", close_tag)
+                        )
 
         return reports
 

--- a/src/notification/templates/dou_template.html
+++ b/src/notification/templates/dou_template.html
@@ -373,7 +373,7 @@
                                         </div>
 
                                         {% if title %}
-                                            <h3><strong>Resultados para: </strong> {{ title }}</h3>
+                                            <h3><strong>Resultados para: </strong> {{ title | safe }}</h3>
                                         {% endif %}
 
                                     {% endif %}
@@ -390,10 +390,10 @@
                                         {% if document.url_new_tab %}target="_blank"{% endif %}>
                                             {{ document.title | safe }}
                                         </a>
-                                        <div class="section-marker">{{ department| safe }}</div>
+                                        <div class="section-marker">{{ department | safe }}</div>
                                         <div class="section-marker">{{ document.section | safe }}</div>
 
-                                        <div class="abstract">{{ document.abstract | safe}}</div>
+                                        <div class="abstract">{{ document.abstract | safe }}</div>
 
                                         <div class="date">{{ document.date }}</div>
 

--- a/src/utils/select_terms.py
+++ b/src/utils/select_terms.py
@@ -111,6 +111,6 @@ class TermSelector:
 
         terms_df = db_hook.get_pandas_df(sql)
         # Remove unnecessary spaces and change null for ''
-        terms_df = terms_df.applymap(lambda x: str.strip(x) if pd.notnull(x) else "")
+        terms_df = terms_df.map(lambda x: str.strip(x) if pd.notnull(x) else "")
 
         return terms_df.to_json(orient="columns")

--- a/tests/inlabs_hook_test.py
+++ b/tests/inlabs_hook_test.py
@@ -136,6 +136,19 @@ def test_rename_section(inlabs_hook, pub_name_in, pub_name_out):
             "Pellentesque vel elementum mauris, id semper tellus.",
             "Pellentesque vel <%%>elementum</%%> mauris, id semper <%%>tellus</%%>.",
         ),
+        (
+            # Term without accent matches accented text (e.g. user searches
+            # "Flavia" but DOU publishes "Flávia")
+            ["Flavia Teixeira Guerreiro"],
+            "Designar Flávia Teixeira Guerreiro para o cargo.",
+            "Designar <%%>Flávia Teixeira Guerreiro</%%> para o cargo.",
+        ),
+        (
+            # Term with accent matches non-accented text
+            ["Flávia"],
+            "Designar Flavia para o cargo.",
+            "Designar <%%>Flavia</%%> para o cargo.",
+        ),
     ],
 )
 def test_highlight_terms(inlabs_hook, term, texto_in, texto_out):


### PR DESCRIPTION
# fix: highlight e busca de termos com insensibilidade a acentuação

## Descrição

- Estende a busca por termos de texto ao campo `identifica` (título da seção), permitindo que publicações sejam encontradas mesmo quando o termo aparece apenas no título
- Corrige o highlight de termos quando há divergência de acentuação entre o termo buscado e o texto publicado (ex: "Ministerio" destaca "Ministério")
- Aplica highlight de termos também no campo `identifica` na notificação de e-mail

## Tipo de mudança

- [x] correção de bug
- [ ] nova funcionalidade
- [ ] melhoria de código ou refatoração
- [ ] atualização de documentação
- [ ] outra (descreva abaixo)

## Checklist

- [x] o código segue os padrões definidos no projeto
- [x] os testes existentes não foram quebrados
- [ ] a documentação foi atualizada (se aplicável)
- [x] o ambiente de desenvolvimento foi testado com as mudanças
- [x] o pull request está vinculado a uma issue (#279)

## Issue relacionada

close #279 

## Considerações finais

O método `_highlight_terms` passou de `@staticmethod` para método de instância para acessar `_normalize`. A lógica de highlight agora opera sobre o texto normalizado (sem acentos) e mapeia as posições de volta ao texto original — com fallback para match direto caso os tamanhos divirjam. O campo `identifica` também recebe highlight e substituição das tags `<%%>` no template de e-mail.
