### PR TITLE
docs: add Ro-DOU usage and responsibility guide

### DIFF
--- a/docs/docs/outros/Guia_de_Uso.md
+++ b/docs/docs/outros/Guia_de_Uso.md
@@ -1,0 +1,26 @@
+## Guia de Uso e Responsabilidade do Ro-DOU
+
+Nesta seção, estão descritas as diretrizes de uso, responsabilidades e limitações relacionadas ao Ro-DOU. É importante que todos os usuários estejam cientes dessas condições antes de utilizar o sistema.
+
+### 1. **Natureza do Software**  
+O Ro-DOU é um software livre licenciado sob a GNU GPL v3.0. Ele é disponibilizado “como está” (“as is”), sem garantias de funcionamento contínuo, ausência de erros ou adequação a finalidades específicas. O uso do sistema é de inteira responsabilidade do usuário.
+
+
+### 2. **Fontes de Dados**  
+O sistema atua como um automatizador de coleta e leitura de fontes públicas, como a Imprensa Nacional e diários oficiais. O Ro-DOU não se responsabiliza pela veracidade, integridade, atualização ou possíveis erros presentes nos dados fornecidos por essas fontes.
+
+
+### 3. **Apoio e Suporte**  
+O suporte oficial é direcionado prioritariamente às unidades do MGI previamente definidas. Para demais usuários, como comunidade, órgãos externos ou empresas privadas, o suporte ocorre de forma colaborativa por meio da documentação e dos canais abertos (ex.: GitHub), sem garantia de prazo de atendimento.
+
+
+### 4. **Uso por Terceiros**  
+Incentivamos que outros órgãos e entidades criem suas próprias instâncias do Ro-DOU. Ao fazer isso, cada organização assume total responsabilidade pela gestão do ambiente, incluindo manutenção, configuração e conformidade com a LGPD.
+
+
+### 5. **Responsabilidade e Dados**  
+O MGI não acessa, opera ou controla dados em instalações realizadas por terceiros. Dessa forma, não se responsabiliza por perdas de dados, incidentes de segurança ou quaisquer danos decorrentes da utilização do software fora de sua infraestrutura oficial.
+
+
+### 6. **Identidade Institucional**  
+O uso do código-fonte é livre, porém as marcas “Ro-DOU”, “MGI” e símbolos oficiais são protegidos. Não é permitido utilizar esses elementos de forma que sugira vínculo, apoio ou oficialidade em projetos derivados, evitando confusão institucional.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - Oficinas e mídias:
     - Conteúdos sobre o Ro-DOU: oficinas_midias/oficinas_midias.md
   - Outros:
+    - Guia de Uso e Responsabilidade: outros/Guia_de_Uso.md
     - FAQ: outros/faq.md
     - Links relevantes: outros/links.md
     - Contato: outros/contato.md


### PR DESCRIPTION
Adds the "Usage and Responsibility Guide" section to the Ro-DOU documentation.

Includes:
- Software usage guidelines
- Disclaimer information
- Support policies
- Third-party usage responsibilities