### PR TITLE
isolate AI dependencies on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,17 @@ RUN pip install --upgrade pip && \
 # Copy and install requirements.txt
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+ARG AI_PROVIDERS=""
+
+COPY requirements-ai.txt .
+
+RUN if [ -n "$AI_PROVIDERS" ]; then \
+  for provider in $AI_PROVIDERS; do \
+      grep "# $provider" requirements-ai.txt | cut -d'#' -f1 >> /tmp/filtered.txt; \
+  done && \
+  pip install -r /tmp/filtered.txt; \
+  fi
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@ create-azure-openai-api-key-variable
 create-logs-dir:
 	mkdir -p ./mnt/airflow-logs -m a=rwx
 
+
+AI_PROVIDERS ?=
+
+build:
+	@echo "AI_PROVIDERS=$(AI_PROVIDERS)" 
+	docker build \
+		--build-arg AI_PROVIDERS="$(AI_PROVIDERS)" .
+
 setup-containers:
 	docker compose up -d --force-recreate --remove-orphans
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: run
 run: \
 create-logs-dir \
+build \
 setup-containers \
 create-example-variable \
 create-email-admim-variable \
@@ -24,9 +25,9 @@ create-logs-dir:
 AI_PROVIDERS ?=
 
 build:
-	@echo "AI_PROVIDERS=$(AI_PROVIDERS)" 
-	docker build \
-		--build-arg AI_PROVIDERS="$(AI_PROVIDERS)" .
+	@echo "AI_PROVIDERS=$(AI_PROVIDERS)"
+	docker compose build \
+		--build-arg AI_PROVIDERS="$(AI_PROVIDERS)"
 
 setup-containers:
 	docker compose up -d --force-recreate --remove-orphans
@@ -140,7 +141,7 @@ activate-inlabs-load-dag:
 			\"is_paused\": false \
 			}' > /dev/null;"
 
-create-azure-openai-endpoint-variable:	
+create-azure-openai-endpoint-variable:
 	@echo "Creating 'AZURE_OPENAI_ENDPOINT' Airflow variable"
 	@docker exec airflow-webserver sh -c \
 		"if ! curl -f -s -LI 'http://localhost:8080/api/v1/variables/AZURE_OPENAI_ENDPOINT' --user \"airflow:airflow\" > /dev/null; \

--- a/docs/docs/como_utilizar/habilitando_ia.md
+++ b/docs/docs/como_utilizar/habilitando_ia.md
@@ -1,5 +1,4 @@
 # Integração com Inteligência Artifical Generativa
-
 O Ro-DOU permite a utilização de modelos de inteligência artificial generativa para geração automática de resumos das publicações encontradas no Diário Oficial da União (DOU). A integração se dá com um provedor de IA existente no mercado.
 
 Essa funcionalidade é especialmente útil para reduzir o tempo de análise, destacando rapidamente o conteúdo mais relevante de cada publicação. Além disso, permite a customização do prompt, possibilitando adaptar o formato do resumo conforme a necessidade do usuário — como apresentação em tópicos, nível de detalhamento, tipo de linguagem, entre outros (parâmetro ai_custom_prompt).
@@ -14,58 +13,59 @@ Atualmente, são suportados os seguintes provedores de IA:
 ⚠️ **Disponível apenas para a fonte INLABS**
 
 ⚠️ **Atenção aos custos**
-
 A utilização de modelos de IA pode gerar custos baseados no consumo de tokens. Recomenda-se verificar junto ao provedor os valores praticados e escolher o modelo mais adequado para o seu cenário.
-
 Para ajudar no controle de custos, ajuste o parâmetro ai_pub_limit, que permite limitar a quantidade de publicações processadas por IA em cada execução. Isso é especialmente importante em buscas com grande volume de resultados.
 
 ⚠️ **Veracidade das informações**
-
 O texto gerado por IA pode conter informações inverídicas, imprecisas ou incompletas, devendo ser utilizado apenas como apoio à análise e sempre validado com a fonte original.
 
+## Instalação
+
+As dependências de IA são opcionais e controladas pelo argumento de build `AI_PROVIDERS`. Se nenhum provedor for especificado, as dependências de IA são ignoradas.
+
+```bash
+# Build com um provedor
+make build AI_PROVIDERS="openai"
+
+# Build com múltiplos provedores
+make build AI_PROVIDERS="openai gemini"
+```
+
+Provedores disponíveis: `openai`, `gemini`, `claude`.
 
 ## Parâmetros da DAG
 - **ai_config** *(obrigatório)*: Configurações do provedor de IA (Disponível apenas para INLABS)
-    - **provider** *(obrigatório)*: Provedor de LLM a ser utilizado. Valores aceitos: `openai`, `gemini`, `claude`, `azure`.
-    - **api_key_var** *(obrigatório)*: Nome da variável do Airflow que contém a chave de API do provedor.
-    - **model** *(obrigatório)*: Modelo da API de IA suportado pelo provider. (ex: gpt-4o-mini)
-
+- **provider** *(obrigatório)*: Provedor de LLM a ser utilizado. Valores aceitos: `openai`, `gemini`, `claude`, `azure`.
+- **api_key_var** *(obrigatório)*: Nome da variável do Airflow que contém a chave de API do provedor.
+- **model** *(obrigatório)*: Modelo da API de IA suportado pelo provider. (ex: gpt-4o-mini)
 ### Observação
-
 Para o provider **Azure**, é necessário configurar, além dos parâmetros acima, as seguintes variáveis no Apache Airflow:
-
 - `AZURE_OPENAI_ENDPOINT`
 - `AZURE_OPENAI_API_VERSION`
 - `AZURE_OPENAI_DEPLOYMENT`
 - `AZURE_OPENAI_API_KEY`
-
 ## Parâmetros da Pesquisa (Search)
 - **ai_config** *(obrigatório)*: Configurações de IA para geração de resumos automáticos. (Disponível apenas para INLABS)
-    - **use_ai_summary** *(opcional)*: Habilita a geração de resumos automáticos com IA para as publicações encontradas.
+- **use_ai_summary** *(opcional)*: Habilita a geração de resumos automáticos com IA para as publicações encontradas.
       Valores: `True` ou `False`. Default: `False`. (Disponível apenas para INLABS)
-    - **ai_pub_limit** *(opcional)*: Número máximo de publicações que serão resumidas por IA na execução da DAG. Default: 5
-    - **ai_custom_prompt** *(opcional)*: Prompt personalizado enviado ao modelo de IA para orientar a geração dos resumos.
-    - **temperature** *(opcional)*: Parâmetro de temperature para o gerador de IA. Valores entre 0.0 e 1.
-        - Valores mais baixos (próximos de 0.0) tornam as respostas mais determinísticas e consistentes.
-        - Valores mais altos (até 1.0) aumentam a diversidade e criatividade das respostas.
-    - **max_tokens** *(opcional)*: Número máximo de tokens que podem ser gerados na resposta da IA.
+- **ai_pub_limit** *(opcional)*: Número máximo de publicações que serão resumidas por IA na execução da DAG. Default: 5
+- **ai_custom_prompt** *(opcional)*: Prompt personalizado enviado ao modelo de IA para orientar a geração dos resumos.
+- **temperature** *(opcional)*: Parâmetro de temperature para o gerador de IA. Valores entre 0.0 e 1.
+- Valores mais baixos (próximos de 0.0) tornam as respostas mais determinísticas e consistentes.
+- Valores mais altos (até 1.0) aumentam a diversidade e criatividade das respostas.
+- **max_tokens** *(opcional)*: Número máximo de tokens que podem ser gerados na resposta da IA.
     Default: `200`
-
-
 ### Prompt padrão (default)
 ```
 Você é um assistente especializado em análise de
 publicações do Diário Oficial da União (DOU).
 Resuma o texto em uma única frase objetiva, fiel ao conteúdo original, em português brasileiro.
 Inclua o termo "{}" no texto.
-
 O resumo deve focar em:
 - órgão responsável
 - tipo de ato
 - ação principal
-
 Não invente informações. Não use markdown. Retorne apenas a frase.
 ```
-
 ### Observações
 - Caso o use_summary esteja habilitado como True: Será considerado o campo da ementa e não será processado para geração de resumo por IA

--- a/docs/docs/como_utilizar/habilitando_ia.md
+++ b/docs/docs/como_utilizar/habilitando_ia.md
@@ -3,6 +3,10 @@ O Ro-DOU permite a utilização de modelos de inteligência artificial generativ
 
 Essa funcionalidade é especialmente útil para reduzir o tempo de análise, destacando rapidamente o conteúdo mais relevante de cada publicação. Além disso, permite a customização do prompt, possibilitando adaptar o formato do resumo conforme a necessidade do usuário — como apresentação em tópicos, nível de detalhamento, tipo de linguagem, entre outros (parâmetro ai_custom_prompt).
 
+Neste vídeo, demonstramos na prática como configurar e habilitar a integração com IA Generativa no Ro-DOU, utilizando a fonte de dados INLABS para automação de resumos.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/tP18HtsI-0g?si=MTjvx_0GOMVYF_Hb" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 Atualmente, são suportados os seguintes provedores de IA:
 
 * OpenAI

--- a/docs/docs/como_utilizar/instalacao.md
+++ b/docs/docs/como_utilizar/instalacao.md
@@ -145,43 +145,6 @@ Quando tiver terminado de utilizar o ambiente de teste do Ro-DOU, desligue-o por
 make down
 ```
 
-### Configurando o ambiente de produção
-
-#### Requisitos
-
-* 4Gb de memória RAM
-* 2Gb de espaço em disco
-* Sistema operacional Linux ou Windows com WSL
-* Docker
-
-Para instalação em um cluster kubernetes, [clique aqui](instalacao_k8s.md)
-
-
-1. Clonar o repositório do código no Github
-[https://github.com/gestaogovbr/Ro-dou](https://github.com/gestaogovbr/Ro-dou). Abra o terminal e execute os comandos abaixo:
-
-```bash
-git clone https://github.com/gestaogovbr/Ro-dou
-cd Ro-Dou
-```
-Para utilizar o Ro-DOU em ambiente de produção, é necessário que o servidor tenha disponível um serviço SMTP que será utilizado pelo Apache Airflow para envio de mensagens de e-mail pela Internet, ou configurar um webhook com Slack ou Discord. Siga os seguintes passos:
-
-2. Utilize as credenciais do serviço SMTP (host, usuário, senha, porta etc.)
-para editar o arquivo `docker-compose.yml`, substituindo as variáveis referentes ao serviço SMTP, a exemplo de `AIRFLOW__SMTP__SMTP_HOST`.
-
-3. Ao final do arquivo `docker-compose.yml`, remova as linhas que declaram o serviço **smtp4dev**, uma vez que ele não será mais necessário.
-
-4. O repositório já vem com comandos pré-definidos no Makefile. Para rodar o sistema, basta:
-
-```bash
-make run
-```
-Este comando baixa as imagens Docker necessárias, efetua o build do container Docker do Ro-DOU e executa todos os demais passos necessários.
-
-5. Opcional: Configurando o INLABS como fonte de dados:
-
-**Observação:** Para utilizar o `source: - INLABS`, é necessário alterar a conexão `inlabs_portal` no Apache Airflow, apontando o usuário e senha de autenticação do portal. Um novo usuário pode ser cadastrado pelo portal [INLABS](https://inlabs.in.gov.br/acessar.php). A DAG
-que realiza o download dos arquivos do INLABS é a **ro-dou_inlabs_load_pg**.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/NpumeNLBuI8?si=g_i99R2d2k23yISX" title="Utilizando o INLABS como fonte de dados-pt1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/docs/docs/como_utilizar/instalacao.md
+++ b/docs/docs/como_utilizar/instalacao.md
@@ -1,6 +1,6 @@
 ## Instalação e configuração
 
-**⚠️Observação:** Para instalar e executar este projeto no Windows, recomenda-se utilizar o [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/pt-br/windows/wsl/).   Certifique-se de que o WSL está devidamente instalado e configurado em seu sistema antes de prosseguir com oa passos de instalação, certifique-se também de habilitar o [docker no WSL](https://learn.microsoft.com/pt-br/windows/wsl/tutorials/wsl-containers)
+**⚠️Observação:** Para instalar e executar este projeto no Windows, recomenda-se utilizar o [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/pt-br/windows/wsl/).   Certifique-se de que o WSL está devidamente instalado e configurado em seu sistema antes de prosseguir com os passos de instalação, certifique-se também de habilitar o [docker no WSL](https://learn.microsoft.com/pt-br/windows/wsl/tutorials/wsl-containers)
 
 * [Como instalar e configurar o WSL](instalacao_wsl_windows.md)
 * [Como habilitar o docker no WSL](habilitacao_docker_no_wsl.md)
@@ -71,7 +71,7 @@ Creating 'inlabs' database
 Creating 'dou_inlabs' schema
 ```
 
-1. Confirme se o serviço do Airflow — do qual o Ro-DOU depende — está funcionando, acessando-o pelo navegador no endereço:
+4. Confirme se o serviço do Airflow — do qual o Ro-DOU depende — está funcionando, acessando-o pelo navegador no endereço:
 
     [http://localhost:8080/](http://localhost:8080/)
 
@@ -97,11 +97,35 @@ que realiza o download dos arquivos do INLABS é a **ro-dou_inlabs_load_pg**.
 
 8. Opcional: Configurando variáveis de ambiente para IA (resumo com IA):
 
-O Ro-DOU suporta geração de resumos automáticos de publicações utilizando modelos de linguagem (LLMs). Para habilitar essa funcionalidade, é necessário configurar as variáveis do provedor de IA no Apache Airflow.
+O Ro-DOU suporta geração de resumos automáticos de publicações utilizando modelos de linguagem (LLMs). Para habilitar essa funcionalidade, é necessário buildar a imagem com o(s) provedor(es) desejado(s) e configurar as variáveis de API no Apache Airflow.
 
-**Provedor suportado: Azure, OpenAI e Gemini**
+**Provedores suportados: Azure, OpenAI, Gemini e Claude**
 
-As seguintes variáveis precisam ser criadas no Airflow:
+**1. Build com o provedor desejado:**
+
+```bash
+# Build com um provedor
+make build AI_PROVIDERS="openai"
+
+# Build com múltiplos provedores
+make build AI_PROVIDERS="openai gemini"
+```
+
+Provedores disponíveis: `openai`, `gemini`, `claude`. Se nenhum provedor for especificado, as dependências de IA são ignoradas e a funcionalidade não estará disponível.
+
+**2. Configurando as variáveis de API no Airflow:**
+
+Para os provedores **OpenAI**, **Gemini** e **Claude**, basta criar uma variável no Airflow com a chave de API do provedor escolhido:
+
+| Variável | Descrição |
+|---|---|
+| `OPENAI_API_KEY` | Chave de API do OpenAI |
+| `GEMINI_API_KEY` | Chave de API do Gemini |
+| `ANTHROPIC_API_KEY` | Chave de API do Claude (Anthropic) |
+
+Para criar a variável, acesse a interface do Airflow em [http://localhost:8080/variable/list/](http://localhost:8080/variable/list/) e adicione a variável com o valor da sua chave.
+
+Para o provedor **Azure**, são necessárias variáveis adicionais:
 
 | Variável | Descrição | Exemplo |
 |---|---|---|
@@ -110,31 +134,27 @@ As seguintes variáveis precisam ser criadas no Airflow:
 | `AZURE_OPENAI_DEPLOYMENT` | Nome do deployment do modelo | `gpt-4o-mini` |
 | `AZURE_OPENAI_API_KEY` | Chave de API do Azure OpenAI | `<sua-chave>` |
 
-**Criando as variáveis automaticamente via Makefile:**
-
-Execute o comando abaixo para criar as variáveis com valores padrão (exceto a chave de API):
+**Criando as variáveis do Azure automaticamente via Makefile:**
 
 ```bash
 make create-azure-openai-variables
 ```
 
-A variável `AZURE_OPENAI_API_KEY` será criada com o valor `<your-api-key>`. Para inserir sua chave real, acesse a interface do Airflow em [http://localhost:8080/variable/list/](http://localhost:8080/variable/list/), localize a variável e edite o valor. Se preferir, você também pode criar todas as variáveis diretamente por essa interface, sem utilizar o Makefile.
+A variável `AZURE_OPENAI_API_KEY` será criada com o valor `<your-api-key>`. Para inserir sua chave real, acesse [http://localhost:8080/variable/list/](http://localhost:8080/variable/list/), localize a variável e edite o valor.
 
-**Observação:** O uso do Makefile é a forma recomendada para criação das variáveis, pois garante que todas sejam criadas com os valores corretos e de forma consistente.
-
-**Configurando a DAG para usar IA:**
+**3. Configurando a DAG para usar IA:**
 
 No arquivo YAML da DAG, adicione o bloco `ai_config` com o provedor e o nome da variável que contém a chave de API:
 
 ```yaml
 search:
   use_ai_summary: True
-  ai_pub_limit: 5  # limite de publicações a serem resumidas por execução
+  ai_pub_limit: 5
   ai_custom_prompt: |
     Você é um assistente que cria resumos concisos de publicações oficiais.
 ai_config:
-  provider: openai
-  api_key_var: AZURE_OPENAI_API_KEY  # nome da variável do Airflow com a chave
+  provider: openai  # openai | gemini | claude | azure
+  api_key_var: OPENAI_API_KEY
 ```
 
 9. Desligando o ambiente:

--- a/requirements-ai.txt
+++ b/requirements-ai.txt
@@ -1,0 +1,3 @@
+google-genai==1.73.1 # gemini
+anthropic==0.96.0    # claude
+openai==2.16.0       # openai

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,8 @@ pytest-mock==3.10.0
 unidecode==1.2.0
 requests==2.32.2
 html2text==2024.2.26
-openai==2.16.0
 pydantic-ai-slim==1.54.0
 markdown==3.6.0
 apprise==1.9.7
 Jinja2==3.1.4
-google-genai==1.73.1
-anthropic==0.96.0
+


### PR DESCRIPTION
This change isolates AI-related dependencies during the Docker build process, making them optional instead of mandatory.

A new build argument `AI_PROVIDERS` was introduced to control which AI providers should be installed. The Dockerfile dynamically filters dependencies from `requirements-ai.txt` based on the selected providers and installs only the relevant libraries.