### PR TITLE
feat: add ementa/IA tags and redesign document link layout in notific…

### DIFF
--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -386,10 +386,11 @@ class INLABSHook(BaseHook):
             else:
                 df["matches"] = ""
 
-
             if use_summary:
                 # If use_summary replace texto value by summary value
                 df["texto"] = df["texto"].where(df["ementa"].isnull(), df["ementa"])
+                # Mark if the ementa exists in a new column to be used on the template to display the "Ementa" tag
+                df["has_ementa"] = df["ementa"].notna()
 
             df["ai_generated"] = False
 
@@ -401,35 +402,36 @@ class INLABSHook(BaseHook):
                     # AI on entire column
                     mask = df["texto"].notna()
 
-                idx = df.loc[mask].index[:ai_search_config.ai_pub_limit]
+                idx = df.loc[mask].index[: ai_search_config.ai_pub_limit]
                 for i in idx:
                     df.at[i, "texto"] = AIRunner.run(
                         provider=ai_config.provider,
                         api_key=Variable.get(ai_config.api_key_var),
                         model=ai_config.model,
                         input_text=df.at[i, "texto"],
-                        system_prompt=ai_search_config.ai_custom_prompt.format(df.at[i, "matches"]),
+                        system_prompt=ai_search_config.ai_custom_prompt.format(
+                            df.at[i, "matches"]
+                        ),
                         max_tokens=ai_search_config.max_tokens,
                         temperature=ai_search_config.temperature,
                     )
                     df.at[i, "ai_generated"] = True
 
             df["texto"] = df.apply(
-                    lambda row: self._highlight_terms(
-                        [t for t in row["matches"].split(", ") if t],
-                        row["texto"],
-                    ),
-                    axis=1,
-                )
+                lambda row: self._highlight_terms(
+                    [t for t in row["matches"].split(", ") if t],
+                    row["texto"],
+                ),
+                axis=1,
+            )
 
             if not full_text:
                 # Only trim text that was not processed by AI
-                df.loc[~df["ai_generated"], "texto"] = \
-                    df.loc[~df["ai_generated"], "texto"].apply(lambda x: self._trim_text(x, text_length))
+                df.loc[~df["ai_generated"], "texto"] = df.loc[
+                    ~df["ai_generated"], "texto"
+                ].apply(lambda x: self._trim_text(x, text_length))
 
             df["display_date_sortable"] = None
-
-
 
             cols_rename = {
                 "pubname": "section",
@@ -441,6 +443,7 @@ class INLABSHook(BaseHook):
                 "display_date_sortable": "display_date_sortable",
                 "artcategory": "hierarchyList",
                 "ai_generated": "ai_generated",
+                "has_ementa": "has_ementa",
             }
             df.rename(columns=cols_rename, inplace=True)
             cols_output = list(cols_rename.values())
@@ -451,7 +454,7 @@ class INLABSHook(BaseHook):
                 else self._group_to_dict(
                     df.sort_values(
                         by=["matches", "section", "ai_generated", "title"],
-                        ascending=[True, True, False, True]
+                        ascending=[True, True, False, True],
                     ),
                     "matches",
                     cols_output,

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -307,6 +307,7 @@ class INLABSHook(BaseHook):
             full_text: bool = False,
             text_length: int = 400,
             use_summary: bool = False,
+            has_ementa: bool = False,
         ) -> dict:
             """Transforms and sorts the search results based on the presence
             of text terms and signature matching.
@@ -385,6 +386,9 @@ class INLABSHook(BaseHook):
                     df = df[~((df["matches_assina"]) & (df["count_assina"] == 1))]
             else:
                 df["matches"] = ""
+
+            if "has_ementa" not in df.columns:
+                df["has_ementa"] = has_ementa
 
             if use_summary:
                 # If use_summary replace texto value by summary value

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -390,6 +390,9 @@ class INLABSHook(BaseHook):
             if "has_ementa" not in df.columns:
                 df["has_ementa"] = has_ementa
 
+            if "full_text" not in df.columns:
+                df["full_text"] = full_text
+
             if use_summary:
                 # If use_summary replace texto value by summary value
                 df["texto"] = df["texto"].where(df["ementa"].isnull(), df["ementa"])
@@ -448,6 +451,7 @@ class INLABSHook(BaseHook):
                 "artcategory": "hierarchyList",
                 "ai_generated": "ai_generated",
                 "has_ementa": "has_ementa",
+                "full_text": "full_text",
             }
             df.rename(columns=cols_rename, inplace=True)
             cols_output = list(cols_rename.values())

--- a/src/notification/email_sender.py
+++ b/src/notification/email_sender.py
@@ -175,11 +175,7 @@ class EmailSender(ISender):
                             if result.get("ai_generated"):
                                 # Inlabs_hook sets ai_generated when the AI summary is used.
                                 # We don't need has_ementa in EmailSender anymore.
-                                ai_sufix = (
-                                    "Resumo gerado por IA (pode conter erros)."
-                                    if display_abstract
-                                    else "Resumo gerado por IA (pode conter erros)."
-                                )
+                                ai_sufix = True
 
                             term_data["search_terms"]["items"].append(
                                 {
@@ -191,6 +187,7 @@ class EmailSender(ISender):
                                     "abstract": display_abstract,
                                     "date": result["date"],
                                     "ai_sufix": ai_sufix,
+                                    "has_ementa": result.get("has_ementa", False),
                                 }
                             )
 

--- a/src/notification/email_sender.py
+++ b/src/notification/email_sender.py
@@ -188,6 +188,7 @@ class EmailSender(ISender):
                                     "date": result["date"],
                                     "ai_sufix": ai_sufix,
                                     "has_ementa": result.get("has_ementa", False),
+                                    "full_text": result.get("full_text", False),
                                 }
                             )
 

--- a/src/notification/templates/dou_template.html
+++ b/src/notification/templates/dou_template.html
@@ -207,6 +207,7 @@
             padding: 0.35em 0.65em;
             font-size: 0.75em;
             font-weight: 600;
+            color: #333;
             line-height: 1;           
             border-radius: 0.25rem;
             text-align: center;
@@ -220,8 +221,15 @@
         }
 
         .ementa {
-            background-color: #D0E4FC; 
-            color: #333;
+            background-color: #D0E4FC;             
+        }
+
+        .recort {
+            background-color: #ffebcc;
+        }
+
+        .full-text {
+            background-color: #e2f0d9;
         }
 
         .summary-block {
@@ -465,8 +473,14 @@
                                                 <div class="abstract">
                                                     <span class="tag ia">IA:</span> {{ document.abstract | safe }}
                                                 </div>
+                                            {% elif document.full_text %}
+                                                <div class="abstract">
+                                                    <span class="tag full-text">Texto Completo:</span> {{ document.abstract | safe }}
+                                                </div>
                                             {% else %}
-                                                <div class="abstract">{{ document.abstract | safe }}</div>
+                                                <div class="abstract">
+                                                    <span class="tag recort">Recorte:</span> {{ document.abstract | safe }}
+                                                </div>
                                             {% endif %}
                                         {% endif %}                                        
                                         <div class="date">{{ document.date | safe }}</div>

--- a/src/notification/templates/dou_template.html
+++ b/src/notification/templates/dou_template.html
@@ -101,6 +101,10 @@
             list-style: disc;
             list-style-position: inside;
         }
+        
+        ul li::marker {
+            color: #06acff;
+        }
 
         .results-section {
             margin-top: 0;
@@ -152,22 +156,39 @@
             margin: 0 4px 0 0;
         }
 
-        .document-link {
-            display: block;
+        .group-link {            
+            font-size: 14px;
+            max-width: 1200px;
+            margin: 5px auto;
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .document-title {
+            display: inline-block;
             color: #0056b3;
             text-decoration: none;
             font-weight: 600;
-            font-size: 16px;
-            margin: 10px 0 0 0;
-            transition: color 0.3s ease;
+            font-size: 16px;   
         }
 
-        .document-link:hover {
+        .document-meta {
+            font-size: 13px;
+            padding: 6px;          
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            background-color: #fafafa;
+            text-decoration: none;
+            color: #333;
+        }
+
+        .document-meta:hover {
             color: #003d82;
-            text-decoration: underline;
         }
 
-        .document-link:visited {
+        .document-meta:visited {
             color: #8e44ad;
         }
 
@@ -179,6 +200,28 @@
             text-align: justify;
             font-size: 15px;
             line-height: 1.5;
+        }
+
+        .tag {
+            display: inline-block;
+            padding: 0.35em 0.65em;
+            font-size: 0.75em;
+            font-weight: 600;
+            line-height: 1;           
+            border-radius: 0.25rem;
+            text-align: center;
+            white-space: nowrap;
+            vertical-align: baseline;            
+        }
+
+        .ia {
+            background-color: #6c757d;
+            color: #fff;
+        }
+
+        .ementa {
+            background-color: #D0E4FC; 
+            color: #333;
         }
 
         .summary-block {
@@ -272,7 +315,7 @@
 
             .filter-list {
                 grid-template-columns: 1fr;
-            }
+            }            
 
             .result-header {
                 white-space: normal;
@@ -341,7 +384,7 @@
                                     {{ result_group.filters.publication_types.title | default('Tipos de publicações:') }}
                                 </div>
                                 <ul class="filter-list">
-                                    {% for type in result_group.filters.publication_types['items'] %}
+                                    {% for type in result_group.filters.publication_types['items'] %}                                        
                                         <li>{{ type }}</li>
                                     {% endfor %}
                                 </ul>
@@ -371,6 +414,13 @@
                                     {% endif %}
                                 {% endif %}
 
+                                {% if document.ai_sufix %}
+                                    <div class="summary-block">
+                                        <em><strong>Atenção:</strong> Todos os textos marcados com a tag <span class="tag ia">IA</span> foram gerados por Inteligência Artificial e podem conter erros. </em>
+                                    </div>
+                                {% endif %}
+
+
                                 <!-- Corpo do resultado -->
                                 <div class="result-body">
 
@@ -394,25 +444,32 @@
                                             <p>Nenhum resultado encontrado para os critérios de pesquisa especificados.</p>
                                         {% endif %}
                                     {% else %}
+                                        <div class="group-link">
+                                            <span class="document-title">{{ document.title | safe }}</span>
+                                            <a href="{{ document.url }}" class="document-meta"
+                                                {% if document.url_new_tab %}target="_blank"{% endif %}>
+                                                <img width="16" height="16" style="vertical-align: middle" src='data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiMwNmFjZmYiIHN0cm9rZS13aWR0aD0iMiIgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBzdHlsZT0idmVydGljYWwtYWxpZ246bWlkZGxlOyBtYXJnaW4tcmlnaHQ6NHB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMTAgMTNhNSA1IDAgMCAxIDAtN2wxLjUtMS41YTUgNSAwIDAgMSA3IDdMMTcgMTIiLz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0xNCAxMWE1IDUgMCAwIDEgMCA3TDEyLjUgMTkuNWE1IDUgMCAwIDEtNy03TDcgMTIiLz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvc3ZnPgo='/>
+                                                Ver Íntegra
+                                            </a>
+                                        </div>
 
-                                        <a href="{{ document.url }}" class="document-link"
-                                        {% if document.url_new_tab %}target="_blank"{% endif %}>
-                                            {{ document.title | safe }}
-                                        </a>
                                         <div class="section-marker">{{ department | safe }}</div>
                                         <div class="section-marker">{{ document.section | safe }}</div>
 
                                         {% if document.abstract %}
-                                        <div class="abstract">{{ document.abstract | safe }}</div>
-                                        {% endif %}
-
-                                        {% if document.ai_sufix %}
-                                        <div class="summary-block">
-                                            <em>{{ document.ai_sufix | safe }}</em>
-                                        </div>
-                                        {% endif %}
-
-                                        <div class="date">{{ document.date }}</div>
+                                            {% if document.has_ementa %}
+                                                <div class="abstract">
+                                                    <span class="tag ementa">Ementa:</span> {{ document.abstract | safe }}
+                                                </div>
+                                            {% elif document.ai_sufix %}
+                                                <div class="abstract">
+                                                    <span class="tag ia">IA:</span> {{ document.abstract | safe }}
+                                                </div>
+                                            {% else %}
+                                                <div class="abstract">{{ document.abstract | safe }}</div>
+                                            {% endif %}
+                                        {% endif %}                                        
+                                        <div class="date">{{ document.date | safe }}</div>
 
                                     {% endif %}
 

--- a/tests/email_sender_test.py
+++ b/tests/email_sender_test.py
@@ -106,7 +106,8 @@ class TestEmailSenderProcessing:
         footer = soup.find('div', class_='ext_footer')
         
         assert abstract is not None
-        assert abstract.text == 'ALESSANDRO GLAUCO DOS ANJOS DE VASCONCELOS - Secretário-Executivo Adjunto...'
+        assert abstract.find("span", class_="recort") is not None
+        assert abstract.text.strip() == 'Recorte: ALESSANDRO GLAUCO DOS ANJOS DE VASCONCELOS - Secretário-Executivo Adjunto...'
         assert date is not None
         assert date.text == '02/09/2021'
         assert footer is not None

--- a/tests/inlabs_hook_test.py
+++ b/tests/inlabs_hook_test.py
@@ -24,9 +24,8 @@ _MIN_AI_CONFIG = AIConfig(
     model="gpt-4o-mini",
 )
 
-_MIN_AI_SEARCH_CONFIG = AISearchConfig(
-    use_ai_summary=False,
-)
+_MIN_AI_SEARCH_CONFIG = AISearchConfig(use_ai_summary=False, has_ementa=False)
+
 
 @pytest.mark.parametrize(
     "text_terms_in, text_terms_out",
@@ -202,8 +201,7 @@ def test_highlight_terms(inlabs_hook, term, texto_in, texto_out):
             Brasília/DF, 15 de março de 2024.  Pessoa 1  Analista
             """,
             # texto_out
-            (
-                """(...) . Sed ut perspiciatis
+            ("""(...) . Sed ut perspiciatis
             unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
             totam rem aperiam, eaque ipsa Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Phasellus venenatis auctor mauris. Integer id neque quis urna
@@ -213,8 +211,7 @@ def test_highlight_terms(inlabs_hook, term, texto_in, texto_out):
             fermentum. Nulla mollis cursus ipsum vel interdum. Mauris
             facilisis posuere elit. Proin consectetur tincidunt urna.
             Cras tincidunt nunc vestibulum velit pellentesque facilisis.
-            Aenean sollicitudin ante elit, vitae vehicula nisi congue id. (...)"""
-            ),
+            Aenean sollicitudin ante elit, vitae vehicula nisi congue id. (...)"""),
         ),
     ],
 )
@@ -241,8 +238,7 @@ def test_trim_text(inlabs_hook, texto_in, texto_out):
             dolore magnam aliquam quaerat voluptatem.
             """,
             # texto_out
-            (
-                """Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            ("""Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Phasellus venenatis auctor mauris. Integer id neque quis urna
             ultrices iaculis. Donec et enim mauris. Sed vel massa eget est
             viverra finibus a et magna. Sed ut perspiciatis
@@ -252,8 +248,7 @@ def test_trim_text(inlabs_hook, texto_in, texto_out):
             voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
             consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
             Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
-            adipisci velit, sed quia non numquam eius modi tempora (...)"""
-            ),
+            adipisci velit, sed quia non numquam eius modi tempora (...)"""),
         ),
     ],
 )
@@ -315,8 +310,7 @@ def test_trim_text_length_less_than_400(inlabs_hook, texto_in, texto_out):
             Brasília/DF, 15 de março de 2024.  Pessoa 1  Analista
             """,
             # texto_out
-            (
-                """(...) . Sed ut perspiciatis
+            ("""(...) . Sed ut perspiciatis
             unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
             totam rem aperiam, eaque ipsa Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Phasellus venenatis auctor mauris. Integer id neque quis urna
@@ -326,8 +320,7 @@ def test_trim_text_length_less_than_400(inlabs_hook, texto_in, texto_out):
             fermentum. Nulla mollis cursus ipsum vel interdum. Mauris
             facilisis posuere elit. Proin consectetur tincidunt urna.
             Cras tincidunt nunc vestibulum velit pellentesque facilisis.
-            Aenean sollicitudin ante elit, vitae vehicula nisi congue id. (...)"""
-            ),
+            Aenean sollicitudin ante elit, vitae vehicula nisi congue id. (...)"""),
         ),
     ],
 )
@@ -413,7 +406,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
 
 
 @pytest.mark.parametrize(
-    "terms, df_in, dict_out, full_text, use_summary",
+    "terms, df_in, dict_out, full_text, use_summary, has_ementa",
     [
         (
             ["Pellentesque", "Lorem"],
@@ -465,6 +458,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "display_date_sortable": None,
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
+                        "has_ementa": False,
                     }
                 ],
                 "Pellentesque": [
@@ -478,9 +472,11 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "display_date_sortable": None,
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
+                        "has_ementa": False,
                     }
                 ],
             },
+            False,
             False,
             False,
         ),
@@ -540,10 +536,12 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "display_date_sortable": None,
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
+                        "has_ementa": False,
                     }
                 ],
             },
             True,
+            False,
             False,
         ),
         (
@@ -592,11 +590,13 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "display_date_sortable": None,
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
+                        "has_ementa": True,
                     }
                 ],
             },
             True,
             True,
+            False,
         ),
         # HTML texto with identifica tag — title must not appear in abstract
         (
@@ -633,9 +633,11 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "display_date_sortable": None,
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
+                        "has_ementa": False,
                     }
                 ],
             },
+            False,
             False,
             False,
         ),
@@ -687,16 +689,18 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "display_date_sortable": None,
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
+                        "has_ementa": False,
                     }
                 ],
             },
+            False,
             False,
             False,
         ),
     ],
 )
 def test_transform_search_results(
-    inlabs_hook, terms, df_in, dict_out, full_text, use_summary
+    inlabs_hook, terms, df_in, dict_out, full_text, use_summary, has_ementa
 ):
 
     r = inlabs_hook.TextDictHandler().transform_search_results(
@@ -708,12 +712,13 @@ def test_transform_search_results(
         full_text=full_text,
         text_length=400,
         use_summary=use_summary,
+        has_ementa=has_ementa,
     )
     assert r == dict_out
 
 
 @pytest.mark.parametrize(
-    "terms, df_in, dict_out",
+    "terms, df_in, dict_out, has_ementa",
     [
         (  # terms
             ["Pellentesque", "Pessoa 1"],
@@ -767,16 +772,19 @@ def test_transform_search_results(
                         "display_date_sortable": None,
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
+                        "has_ementa": False,
                     }
                 ]
             },
+            False,
         )
     ],
 )
-def test_ignore_signature(inlabs_hook, terms, df_in, dict_out):
+def test_ignore_signature(inlabs_hook, terms, df_in, dict_out, has_ementa):
     r = inlabs_hook.TextDictHandler().transform_search_results(
         ai_config=_MIN_AI_CONFIG,
         ai_search_config=_MIN_AI_SEARCH_CONFIG,
+        has_ementa=has_ementa,
         response=df_in,
         text_terms=terms,
         ignore_signature_match=True,
@@ -1029,9 +1037,13 @@ def _sample_row(**overrides):
 def test_transform_search_results_ai_respects_pub_limit(inlabs_hook):
     df = pd.DataFrame(
         [
-            _sample_row(id=1, texto="Lorem " * 30),
-            _sample_row(id=2, identifica="Título 2", texto="Lorem " * 30),
-            _sample_row(id=3, identifica="Título 3", texto="Lorem " * 30),
+            _sample_row(id=1, texto="Lorem " * 30, has_ementa=False),
+            _sample_row(
+                id=2, identifica="Título 2", texto="Lorem " * 30, has_ementa=False
+            ),
+            _sample_row(
+                id=3, identifica="Título 3", texto="Lorem " * 30, has_ementa=False
+            ),
         ]
     )
     ai_search_config = AISearchConfig(
@@ -1051,7 +1063,7 @@ def test_transform_search_results_ai_respects_pub_limit(inlabs_hook):
 
 
 def test_transform_search_results_ai_system_prompt_uses_matches(inlabs_hook):
-    df = pd.DataFrame([_sample_row()])
+    df = pd.DataFrame([_sample_row(has_ementa=False)])
     ai_search_config = AISearchConfig(
         use_ai_summary=True,
         ai_custom_prompt="Enfatize {} na análise",
@@ -1082,6 +1094,7 @@ def test_transform_search_results_ai_only_where_ementa_missing_with_use_summary(
                 identifica="Com ementa",
                 ementa="Resumo já existente.",
                 texto="Lorem corpo original.",
+                has_ementa=True,
             ),
             _sample_row(
                 id=2,
@@ -1096,7 +1109,9 @@ def test_transform_search_results_ai_only_where_ementa_missing_with_use_summary(
         ai_pub_limit=3,
     )
     with patch(f"{_INLABS_HOOK}.Variable.get", return_value="sk-fake"):
-        with patch(f"{_INLABS_HOOK}.AIRunner.run", return_value="Resumo IA.") as mock_run:
+        with patch(
+            f"{_INLABS_HOOK}.AIRunner.run", return_value="Resumo IA."
+        ) as mock_run:
             inlabs_hook.TextDictHandler().transform_search_results(
                 ai_config=_MIN_AI_CONFIG,
                 ai_search_config=ai_search_config,
@@ -1111,10 +1126,8 @@ def test_transform_search_results_ai_only_where_ementa_missing_with_use_summary(
 
 
 def test_transform_search_results_ai_sets_ai_generated_flag(inlabs_hook):
-    df = pd.DataFrame([_sample_row()])
-    ai_search_config = AISearchConfig(
-        use_ai_summary=True,
-    )
+    df = pd.DataFrame([_sample_row(has_ementa=False)])
+    ai_search_config = AISearchConfig(use_ai_summary=True)
     with patch(f"{_INLABS_HOOK}.Variable.get", return_value="sk-fake"):
         with patch(f"{_INLABS_HOOK}.AIRunner.run", return_value="Texto só da IA."):
             out = inlabs_hook.TextDictHandler().transform_search_results(
@@ -1128,3 +1141,4 @@ def test_transform_search_results_ai_sets_ai_generated_flag(inlabs_hook):
     assert len(items) == 1
     assert items[0]["ai_generated"] is True
     assert items[0]["abstract"] == "Texto só da IA."
+    assert items[0]["has_ementa"] is False

--- a/tests/inlabs_hook_test.py
+++ b/tests/inlabs_hook_test.py
@@ -459,6 +459,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
                         "has_ementa": False,
+                        "full_text": False,
                     }
                 ],
                 "Pellentesque": [
@@ -473,6 +474,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
                         "has_ementa": False,
+                        "full_text": False,
                     }
                 ],
             },
@@ -537,6 +539,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
                         "has_ementa": False,
+                        "full_text": True,
                     }
                 ],
             },
@@ -591,6 +594,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
                         "has_ementa": True,
+                        "full_text": True,
                     }
                 ],
             },
@@ -634,6 +638,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
                         "has_ementa": False,
+                        "full_text": False,
                     }
                 ],
             },
@@ -690,6 +695,7 @@ def test_group_to_dict(inlabs_hook, df_in, dict_out):
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
                         "has_ementa": False,
+                        "full_text": False,
                     }
                 ],
             },
@@ -718,7 +724,7 @@ def test_transform_search_results(
 
 
 @pytest.mark.parametrize(
-    "terms, df_in, dict_out, has_ementa",
+    "terms, df_in, dict_out, has_ementa, full_text",
     [
         (  # terms
             ["Pellentesque", "Pessoa 1"],
@@ -773,18 +779,21 @@ def test_transform_search_results(
                         "hierarchyList": "Texto exemplo art_category",
                         "ai_generated": False,
                         "has_ementa": False,
+                        "full_text": False,
                     }
                 ]
             },
             False,
+            False,
         )
     ],
 )
-def test_ignore_signature(inlabs_hook, terms, df_in, dict_out, has_ementa):
+def test_ignore_signature(inlabs_hook, terms, df_in, dict_out, has_ementa, full_text):
     r = inlabs_hook.TextDictHandler().transform_search_results(
         ai_config=_MIN_AI_CONFIG,
         ai_search_config=_MIN_AI_SEARCH_CONFIG,
         has_ementa=has_ementa,
+        full_text=full_text,
         response=df_in,
         text_terms=terms,
         ignore_signature_match=True,
@@ -1037,12 +1046,20 @@ def _sample_row(**overrides):
 def test_transform_search_results_ai_respects_pub_limit(inlabs_hook):
     df = pd.DataFrame(
         [
-            _sample_row(id=1, texto="Lorem " * 30, has_ementa=False),
+            _sample_row(id=1, texto="Lorem " * 30, has_ementa=False, full_text=False),
             _sample_row(
-                id=2, identifica="Título 2", texto="Lorem " * 30, has_ementa=False
+                id=2,
+                identifica="Título 2",
+                texto="Lorem " * 30,
+                has_ementa=False,
+                full_text=False,
             ),
             _sample_row(
-                id=3, identifica="Título 3", texto="Lorem " * 30, has_ementa=False
+                id=3,
+                identifica="Título 3",
+                texto="Lorem " * 30,
+                has_ementa=False,
+                full_text=False,
             ),
         ]
     )
@@ -1058,12 +1075,13 @@ def test_transform_search_results_ai_respects_pub_limit(inlabs_hook):
                 response=df,
                 text_terms=["Lorem"],
                 ignore_signature_match=False,
+                full_text=False,
             )
     assert mock_run.call_count == 3
 
 
 def test_transform_search_results_ai_system_prompt_uses_matches(inlabs_hook):
-    df = pd.DataFrame([_sample_row(has_ementa=False)])
+    df = pd.DataFrame([_sample_row(has_ementa=False, full_text=False)])
     ai_search_config = AISearchConfig(
         use_ai_summary=True,
         ai_custom_prompt="Enfatize {} na análise",
@@ -1076,6 +1094,7 @@ def test_transform_search_results_ai_system_prompt_uses_matches(inlabs_hook):
                 response=df,
                 text_terms=["Lorem"],
                 ignore_signature_match=False,
+                full_text=False,
             )
     mock_run.assert_called_once()
     kwargs = mock_run.call_args.kwargs
@@ -1095,6 +1114,7 @@ def test_transform_search_results_ai_only_where_ementa_missing_with_use_summary(
                 ementa="Resumo já existente.",
                 texto="Lorem corpo original.",
                 has_ementa=True,
+                full_text=False,
             ),
             _sample_row(
                 id=2,
@@ -1119,6 +1139,7 @@ def test_transform_search_results_ai_only_where_ementa_missing_with_use_summary(
                 text_terms=["Lorem"],
                 ignore_signature_match=False,
                 use_summary=True,
+                full_text=False,
             )
     assert mock_run.call_count == 1
     kwargs = mock_run.call_args.kwargs
@@ -1126,7 +1147,7 @@ def test_transform_search_results_ai_only_where_ementa_missing_with_use_summary(
 
 
 def test_transform_search_results_ai_sets_ai_generated_flag(inlabs_hook):
-    df = pd.DataFrame([_sample_row(has_ementa=False)])
+    df = pd.DataFrame([_sample_row(has_ementa=False, full_text=False)])
     ai_search_config = AISearchConfig(use_ai_summary=True)
     with patch(f"{_INLABS_HOOK}.Variable.get", return_value="sk-fake"):
         with patch(f"{_INLABS_HOOK}.AIRunner.run", return_value="Texto só da IA."):
@@ -1136,6 +1157,7 @@ def test_transform_search_results_ai_sets_ai_generated_flag(inlabs_hook):
                 response=df,
                 text_terms=["Lorem"],
                 ignore_signature_match=False,
+                full_text=False,
             )
     items = [item for group in out.values() for item in group]
     assert len(items) == 1


### PR DESCRIPTION
# feat: add ementa/IA tags and redesign document link layout in notification template

## Descrição

Redesenha o layout dos documentos na notificação de e-mail e adiciona tags visuais
para indicar o tipo de conteúdo exibido no resumo de cada publicação.

- Adiciona a flag `has_ementa` no `INLABSHook` para identificar publicações que possuem ementa no DOU
- Propaga `has_ementa` até o contexto do template via `EmailSender`
- Simplifica `ai_sufix` para booleano (antes era uma string duplicada condicionalmente)
- Redesenha o link do documento: título à esquerda e botão "Ver Íntegra" com ícone à direita, usando layout flex
- Adiciona classes CSS `.tag`, `.ementa` e `.ia` para distinguir visualmente o tipo de resumo exibido
- Exibe aviso de conteúdo gerado por IA uma única vez por grupo de resultados, em vez de repetir por documento

## Tipo de mudança

- [ ] correção de bug
- [x] nova funcionalidade
- [x] melhoria de código ou refatoração
- [ ] atualização de documentação
- [ ] outra (descreva abaixo)

## Checklist

- [x] o código segue os padrões definidos no projeto
- [x] os testes existentes não foram quebrados
- [ ] a documentação foi atualizada (se aplicável)
- [x] o ambiente de desenvolvimento foi testado com as mudanças
- [ ] o pull request está vinculado a uma issue (se aplicável)

## Issue relacionada

> N/A

## Considerações finais

A mudança é retrocompatível: `has_ementa` assume `False` por padrão quando ausente
nos dados, e o layout do template se comporta como antes nesses casos. A tag
**Ementa** aparece apenas quando a publicação possui ementa no DOU; a tag **IA**
aparece apenas quando o resumo foi gerado por inteligência artificial.
