### PR TITLE
fix: evitar reenvio de notificações em canais já entregues durante retry

### DIFF
--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -34,6 +34,7 @@ from searchers import BaseSearcher, DOUSearcher, QDSearcher, INLABSSearcher
 
 from airflow.models import Variable
 from ai.runner import AIRunner
+
 SearchResult = Dict[str, Dict[str, Dict[str, List[dict]]]]
 
 
@@ -117,7 +118,7 @@ class DouDigestDagGenerator:
         }
 
         self.on_failure_callback = self._notify_on_failure
-        self.on_retry_callback = None
+        # self.on_retry_callback = None
 
     def _notify_on_failure(self, specs: DAGConfig, context):
         """Function called when the task fails to send a notification to admin"""
@@ -153,14 +154,12 @@ class DouDigestDagGenerator:
         # options that won't show in the "DAG Docs"
         del config["description"]
         del config["doc_md"]
-        doc_md = specs.doc_md + textwrap.dedent(
-            f"""
+        doc_md = specs.doc_md + textwrap.dedent(f"""
 
             **Configuração da dag definida no arquivo `{config_file}`**:
 
 
-            """
-        )
+            """)
         for key, value in config.items():
             doc_md += f"\n**{key.replace('_', ' ').capitalize()}**\n"
 
@@ -403,11 +402,22 @@ class DouDigestDagGenerator:
         self, num_searches: int, specs: DAGConfig, report_date: str, **context
     ) -> str:
         """Send user notification using class Notifier"""
+        ti = context["ti"]
         search_report = self.get_xcom_pull_tasks(num_searches=num_searches, **context)
+
+        already_succeeded = set(
+            ti.xcom_pull(task_ids=ti.task_id, key="succeeded_senders") or []
+        )
 
         notifier = Notifier(specs)
 
-        notifier.send_notification(search_report=search_report, report_date=report_date)
+        succeeded, _ = notifier.send_notification(
+            search_report=search_report,
+            report_date=report_date,
+            skip_senders=already_succeeded,
+        )
+
+        ti.xcom_push(key="succeeded_senders", value=list(already_succeeded | succeeded))
 
     def create_dag(self, specs: DAGConfig, config_file: str) -> DAG:
         """Creates the DAG object and tasks
@@ -424,7 +434,7 @@ class DouDigestDagGenerator:
             "depends_on_past": False,
             "retries": 10,
             "retry_delay": timedelta(minutes=2),
-            "on_retry_callback": self.on_retry_callback,
+            # "on_retry_callback": self.on_retry_callback,
             "on_failure_callback": lambda context: self._notify_on_failure(
                 specs, context
             ),
@@ -564,7 +574,6 @@ class DouDigestDagGenerator:
             tg_exec_searchs >> has_matches_task
 
             has_matches_task >> [send_notification_task, skip_notification_task]
-
 
         return dag
 

--- a/src/notification/notifier.py
+++ b/src/notification/notifier.py
@@ -36,13 +36,40 @@ class Notifier:
         if specs.report.notification:
             self.senders.append(NotificationSender(specs.report))
 
-    def send_notification(self, search_report: str, report_date: str):
-        """Sends the notification to the specified email, Discord, Slack and nother notification services.
+    def send_notification(
+        self,
+        search_report: list,
+        report_date: str,
+        skip_senders: set = None,
+    ) -> tuple[set, dict]:
+        """Sends the notification to each configured channel independently.
+
+        Returns a tuple of (succeeded_sender_names, {failed_sender_name: exception}).
+        Raises RuntimeError at the end if any sender failed, so callers can
+        persist the succeeded set and skip those channels on the next retry.
 
         Args:
-            search_report (str): The report to be sent
+            search_report (list): The report to be sent
             report_date (str): The date of the report
+            skip_senders (set): Sender class names that already succeeded and
+                should be skipped (used on retries to avoid duplicate deliveries)
         """
+        skip_senders = skip_senders or set()
+        succeeded: set = set()
+        failed: dict = {}
 
         for sender in self.senders:
-            sender.send_report(search_report, report_date)
+            sender_name = type(sender).__name__
+            if sender_name in skip_senders:
+                continue
+            try:
+                sender.send_report(search_report, report_date)
+                succeeded.add(sender_name)
+            except Exception as exc:  # noqa: BLE001
+                failed[sender_name] = exc
+
+        if failed:
+            errors = "; ".join(f"{name}: {err}" for name, err in failed.items())
+            raise RuntimeError(f"Notification failed for channel(s): {errors}")
+
+        return succeeded, failed


### PR DESCRIPTION
## Problema

Quando múltiplos canais de notificação estavam configurados (ex.: e-mail e Teams) e a entrega falhava em um deles, a task entrava em modo de retry e reenviava a notificação para **todos** os canais — incluindo aqueles que já haviam sido entregues com sucesso, gerando duplicatas.

## Solução

### `src/notification/notifier.py`
- `send_notification` agora tenta cada sender de forma **independente**, capturando exceções individualmente em vez de propagar na primeira falha.
- Retorna `(succeeded: set, failed: dict)` e só levanta `RuntimeError` ao final, listando todos os canais que falharam.
- Aceita `skip_senders: set` para ignorar senders que já entregaram com sucesso em tentativas anteriores.

### `src/dou_dag_generator.py`
- `send_notification` recupera do XCom o conjunto de senders que já tiveram sucesso (`succeeded_senders`).
- Passa esse conjunto como `skip_senders` ao `Notifier`, que os ignora na tentativa atual.
- Ao final de cada tentativa, persiste o conjunto atualizado de sucesso de volta no XCom.

Dessa forma, em cada retry **apenas os canais que falharam** são tentados novamente.
## Issue relacionadaCloses #292## Revisor@edulauer
## Plano de testes
- [ ] Simular falha em um dos senders (ex.: SMTP inválido) com outro sender funcional e verificar que, no retry, somente o sender com falha é chamado novamente.
- [ ] Verificar que o XCom `succeeded_senders` é criado e atualizado corretamente nos logs da task.
- [ ] Verificar que o comportamento é inalterado quando há apenas um canal configurado.