### PR TITLE
Erro de geração de resumo com o Gemini 

### DIFF
--- a/src/ai/runner.py
+++ b/src/ai/runner.py
@@ -110,7 +110,7 @@ class AIRunner:
         )
         response = client.models.generate_content(
             model=model,
-            contents={'text':system_prompt},
+            contents={'text': f"{system_prompt}\n\n{input_text}"},
             config=types.GenerateContentConfig(
                 temperature = temperature,
                 max_output_tokens = max_tokens,


### PR DESCRIPTION
Corrigido o problema na função _run_gemini onde apenas o system_prompt estava sendo enviado ao modelo, sem incluir o input_text (texto a ser resumido), resultando em respostas solicitando a entrada do conteúdo.

Impacto: a geração de resumos com o Gemini não funcionava corretamente.

Testes realizados:
- Execução da DAG de resumo com Gemini
- Validação da geração correta do resumo após inclusão do input_text

Related to #300