### PR TITLE
Torna o Opensearch opcional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,23 @@ create-inlabs-portal-connection:
 			}' > /dev/null; \
 		fi"
 
+create-opensearch-variable:
+	@echo "Creating 'opensearch' Airflow variable"
+	@docker exec airflow-webserver sh -c \
+		"if ! curl -f -s -LI 'http://localhost:8080/api/v1/variables/ro_dou_inlabs_use_opensearch' --user \"airflow:airflow\" > /dev/null; \
+		then \
+			curl -s -X 'POST' \
+			'http://localhost:8080/api/v1/variables' \
+			-H 'accept: application/json' \
+			-H 'Content-Type: application/json' \
+			--user \"airflow:airflow\" \
+			-d '{ \
+			\"key\": \"RO_DOU_INLABS_USE_OPENSEARCH\", \
+			\"value\": \"False\" \
+			}' > /dev/null; \
+		fi"
+
+
 activate-inlabs-load-dag:
 	@echo "Activating 'dou_inlabs_load_pg' Airflow DAG"
 	@docker exec airflow-webserver sh -c \

--- a/dag_load_inlabs/ro-dou_inlabs_load_pg_dag.py
+++ b/dag_load_inlabs/ro-dou_inlabs_load_pg_dag.py
@@ -219,6 +219,21 @@ def load_inlabs():
             """,
     )
 
+    @task.branch
+    def check_if_should_run_indexer():
+        use_opensearch = os.getenv("RO_DOU_INLABS_USE_OPENSEARCH", "false").lower() == "true"
+
+        if use_opensearch:
+            logging.info("OpenSearch enabled. Running indexer task.")
+            return "indexer_data"
+
+        logging.info("OpenSearch disabled. Skipping indexer task.")
+        return "skip_indexer_data"
+
+    @task
+    def skip_indexer_data():
+        logging.info("Indexer skipped because OpenSearch is disabled.")
+
     @task
     def indexer_data(trigger_date: str) -> None:
         from ro_dou_src.utils.open_search.indexer import Indexer  # type: ignore
@@ -251,7 +266,7 @@ def load_inlabs():
     def trigger_dataset_inlabs():
         pass
 
-    @task
+    @task(trigger_rule="none_failed_min_one_success")
     def remove_directory():
         dest_path = os.path.join(Variable.get("path_tmp"), DEST_DIR)
         subprocess.run(f"rm -rf {dest_path}", shell=True, check=True)
@@ -259,13 +274,22 @@ def load_inlabs():
 
     ## Orchestration
     trigger_date = get_date()
+    run_indexer_task = check_if_should_run_indexer()
+    indexer_task = indexer_data(trigger_date)  # type: ignore
+    skip_indexer_task = skip_indexer_data()
+    remove_directory_task = remove_directory()
+    check_first_run_task = check_if_first_run_of_day()
+
     (
         download_n_unzip_files(trigger_date)
         >> load_data(trigger_date)  # type: ignore
         >> check_loaded_data
-        >> indexer_data(trigger_date)  # type: ignore
-        >> remove_directory()
-        >> check_if_first_run_of_day()
+        >> run_indexer_task
+    )
+    run_indexer_task >> [indexer_task, skip_indexer_task] >> remove_directory_task
+    (
+        remove_directory_task
+        >> check_first_run_task
         >> [trigger_dataset_inlabs_edicao_extra(), trigger_dataset_inlabs()]
     )
 

--- a/dag_load_inlabs/ro-dou_inlabs_load_pg_dag.py
+++ b/dag_load_inlabs/ro-dou_inlabs_load_pg_dag.py
@@ -17,6 +17,7 @@ from airflow.models import Variable  # type: ignore
 
 from airflow.providers.common.sql.operators.sql import SQLCheckOperator  # type: ignore
 
+from ro_dou_src.utils.open_search.config import RO_DOU_INLABS_USE_OPENSEARCH  # type: ignore
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 # Constants
@@ -221,9 +222,8 @@ def load_inlabs():
 
     @task.branch
     def check_if_should_run_indexer():
-        use_opensearch = os.getenv("RO_DOU_INLABS_USE_OPENSEARCH", "false").lower() == "true"
 
-        if use_opensearch:
+        if RO_DOU_INLABS_USE_OPENSEARCH.lower() != 'true':
             logging.info("OpenSearch enabled. Running indexer task.")
             return "indexer_data"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,6 @@ x-airflow-common: &airflow-common
     AIRFLOW_CONN_EXAMPLE_DATABASE_CONN: postgresql://airflow:airflow@postgres:5432/airflow
 
     RO_DOU__DAG_CONF_DIR: /opt/airflow/dags/ro_dou/dag_confs
-    RO_DOU_INLABS_USE_OPENSEARCH: 'false'
     OPENSEARCH_HOST: http://opensearch:9200
     OPENSEARCH_USER: OPENSEARCH_USER
     OPENSEARCH_PASS: OPENSEARCH_PASS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ x-airflow-common: &airflow-common
     AIRFLOW_CONN_EXAMPLE_DATABASE_CONN: postgresql://airflow:airflow@postgres:5432/airflow
 
     RO_DOU__DAG_CONF_DIR: /opt/airflow/dags/ro_dou/dag_confs
-
+    RO_DOU_INLABS_USE_OPENSEARCH: 'false'
     OPENSEARCH_HOST: http://opensearch:9200
     OPENSEARCH_USER: OPENSEARCH_USER
     OPENSEARCH_PASS: OPENSEARCH_PASS

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -1,6 +1,7 @@
 """Apache Airflow Hook to execute DOU searches from INLABS source."""
 
 import copy
+import os
 import re
 import logging
 from datetime import datetime, timedelta
@@ -34,10 +35,10 @@ class INLABSHook(BaseHook):
     """
 
     CONN_ID = "inlabs_db"
-    CLIENT = OpenSearchClient().get_client()
 
     def __init__(self, *args, **kwargs):
         pass
+
 
     @staticmethod
     def _filter_text_terms(text_terms) -> list:
@@ -76,7 +77,7 @@ class INLABSHook(BaseHook):
         use_summary: bool,
         show_relevancy: bool,
         conn_id: str = CONN_ID,
-        client: OpenSearch = CLIENT,
+        client: OpenSearch | None = None,
     ) -> dict:
         """Searches the DOU Database with the provided search terms and processes
         the results.
@@ -98,6 +99,29 @@ class INLABSHook(BaseHook):
                 ``matched_queries`` and propagated to ``matched_terms`` and the
                 legacy ``matches`` field.
         """
+
+        use_opensearch = os.getenv("RO_DOU_INLABS_USE_OPENSEARCH", "false").lower() == "true"
+
+        if not use_opensearch:
+            from .inlabs_hook_sql_mode import INLABSSQLModeHook
+
+            logging.info(
+                "OpenSearch disabled. Using INLABS SQL mode.",
+            )
+            return INLABSSQLModeHook().search_text(
+                ai_config=ai_config,
+                ai_search_config=ai_search_config,
+                search_terms=search_terms,
+                ignore_signature_match=ignore_signature_match,
+                full_text=full_text,
+                text_length=text_length,
+                use_summary=use_summary,
+                show_relevancy=show_relevancy,
+                conn_id=conn_id,
+            )
+
+        if client is None:
+            client = OpenSearchClient().get_client()
 
         logging.info("Search term in INLABS HOOK.")
         logging.info(f"Search terms -> {search_terms}")
@@ -310,6 +334,8 @@ class INLABSHook(BaseHook):
             # Remove blank spaces and convert to uppercase
             df["identifica"] = df["identifica"].str.strip().str.upper()
 
+            should_process_matches = "matched_terms" in df.columns or any(text_terms)
+
             if "matched_terms" in df.columns:
                 df["matched_terms"] = df["matched_terms"].apply(
                     lambda terms: (
@@ -322,6 +348,18 @@ class INLABSHook(BaseHook):
                     lambda terms: ", ".join(terms)
                 )
                 df["matches"] = df["matched_terms_text"]
+            elif any(text_terms):
+                df["matches"] = df.apply(
+                    lambda row: self._find_matches(
+                        row["texto"] + " " + row["identifica"],
+                        keys=text_terms,
+                    ),
+                    axis=1,
+                )
+            elif "matches" not in df.columns:
+                df["matches"] = ""
+
+            if should_process_matches:
                 df["matches_assina"] = df.apply(
                     lambda row: self._normalize(row["matches"])
                     in self._normalize(row["assina"]),
@@ -356,8 +394,6 @@ class INLABSHook(BaseHook):
                 )
                 if ignore_signature_match:
                     df = df[~((df["matches_assina"]) & (df["count_assina"] == 1))]
-            elif "matches" not in df.columns:
-                df["matches"] = ""
 
             def _highlight_row_matches(row):
                 if "<%%>" in row["texto"]:
@@ -485,6 +521,21 @@ class INLABSHook(BaseHook):
                 text = re.sub(r"\s+", " ", text)
                 return text
             return ""
+
+        def _find_matches(self, text: str, keys: list) -> str:
+            """Find configured keys in text using normalized exact matching."""
+            normalized_text = self._normalize(text)
+            matches = [
+                key
+                for key in keys
+                if re.search(
+                    r"\b" + re.escape(self._normalize(key)) + r"\b",
+                    normalized_text,
+                    re.IGNORECASE,
+                )
+            ]
+
+            return ", ".join(sorted(set(matches), key=str.lower))
 
         @staticmethod
         def _normalize(text: str) -> str:

--- a/src/hooks/inlabs_hook.py
+++ b/src/hooks/inlabs_hook.py
@@ -19,7 +19,7 @@ from schemas import AIConfig, AISearchConfig  # type: ignore
 from ai.runner import AIRunner
 
 from ro_dou_src.utils.open_search.client_open_search import OpenSearchClient  # type: ignore
-from ro_dou_src.utils.open_search.config import INDEX_NAME  # type: ignore
+from ro_dou_src.utils.open_search.config import INDEX_NAME, RO_DOU_INLABS_USE_OPENSEARCH  # type: ignore
 from ro_dou_src.utils.open_search.query_builder import OpenSearchQueryBuilder  # type: ignore
 from opensearchpy import OpenSearch  # type: ignore
 
@@ -100,9 +100,7 @@ class INLABSHook(BaseHook):
                 legacy ``matches`` field.
         """
 
-        use_opensearch = os.getenv("RO_DOU_INLABS_USE_OPENSEARCH", "false").lower() == "true"
-
-        if not use_opensearch:
+        if RO_DOU_INLABS_USE_OPENSEARCH.lower() != 'true':
             from .inlabs_hook_sql_mode import INLABSSQLModeHook
 
             logging.info(

--- a/src/hooks/inlabs_hook_sql_mode.py
+++ b/src/hooks/inlabs_hook_sql_mode.py
@@ -1,0 +1,184 @@
+"""Legacy SQL mode for INLABS searches.
+
+This module keeps the pre-OpenSearch implementation isolated while the main
+``inlabs_hook`` decides which backend to use through an environment flag.
+"""
+
+import copy
+import logging
+import re
+from datetime import date
+
+import pandas as pd
+from airflow.providers.postgres.hooks.postgres import PostgresHook  # type: ignore
+
+from .inlabs_hook import INLABSHook
+
+
+class INLABSSQLModeHook(INLABSHook):
+    """Execute INLABS searches directly against PostgreSQL."""
+
+    def search_text(
+        self,
+        ai_config: dict,
+        ai_search_config: dict,
+        search_terms: dict,
+        ignore_signature_match: bool,
+        full_text: bool,
+        text_length: int,
+        use_summary: bool,
+        show_relevancy: bool,
+        conn_id: str = INLABSHook.CONN_ID,
+        client = None,
+    ) -> dict:
+        """Search INLABS using the legacy SQL query path."""
+        hook = PostgresHook(conn_id)
+
+        logging.info("Search term in INLABS SQL mode.")
+        logging.info("Search terms -> %s", search_terms)
+
+        main_search_queries = self._generate_sql(search_terms)
+        hook.run(main_search_queries["create_extension"], autocommit=True)
+        main_search_results = hook.get_pandas_df(main_search_queries["select"])
+
+        extra_search_terms = self._adapt_search_terms_to_extra(
+            copy.deepcopy(search_terms)
+        )
+        extra_search_queries = self._generate_sql(extra_search_terms)
+        extra_search_results = hook.get_pandas_df(extra_search_queries["select"])
+
+        all_results = pd.concat(
+            [main_search_results, extra_search_results], ignore_index=True
+        )
+
+        filtered_text_terms = self._filter_text_terms(search_terms["texto"])
+        return (
+            self.TextDictHandler().transform_search_results(
+                ai_config=ai_config,
+                ai_search_config=ai_search_config,
+                response=all_results,
+                text_terms=filtered_text_terms,
+                ignore_signature_match=ignore_signature_match,
+                full_text=full_text,
+                text_length=text_length,
+                use_summary=use_summary,
+                show_relevancy=show_relevancy,
+            )
+            if not all_results.empty
+            else {}
+        )
+
+    @staticmethod
+    def _generate_sql(payload: dict) -> dict:
+        """Generate legacy SQL queries for INLABS search terms."""
+        allowed_keys = [
+            "name",
+            "pubname",
+            "artcategory",
+            "artcategory_ignore",
+            "arttype",
+            "identifica",
+            "titulo",
+            "subtitulo",
+            "texto",
+            "terms_ignore",
+        ]
+        filtered_dict = {k: payload[k] for k in payload if k in allowed_keys}
+
+        pub_date = payload.get("pubdate", [date.today().strftime("%Y-%m-%d")])
+        pub_date_from = pub_date[0]
+        pub_date_to = pub_date[1] if len(pub_date) > 1 else pub_date_from
+
+        query = (
+            "SELECT * FROM dou_inlabs.article_raw "
+            f"WHERE (pubdate BETWEEN '{pub_date_from}' AND '{pub_date_to}')"
+        )
+
+        term_operators = ["&", "!", "|", "(", ")"]
+
+        conditions = []
+        for key, values in filtered_dict.items():
+            if key == "texto":
+                if any(values):
+                    key_conditions = []
+                    for term in values:
+                        if any(operator in term for operator in term_operators):
+                            operator_str = "".join(term_operators)
+                            sub_terms = re.split(rf"\s*([{operator_str}])\s*", term)
+                            sub_terms = [
+                                sub_term for sub_term in sub_terms if sub_term.strip()
+                            ]
+
+                            sub_conditions = []
+                            like_positive = True
+                            for sub_term in sub_terms:
+                                if sub_term in term_operators:
+                                    if sub_term in {"&", "!"}:
+                                        like_positive = sub_term != "!"
+                                        operator = " AND "
+                                    elif sub_term == "|":
+                                        like_positive = True
+                                        operator = " OR "
+                                    elif sub_term in {"(", ")"}:
+                                        like_positive = True
+                                        operator = sub_term
+                                    sub_conditions.append(operator)
+                                else:
+                                    operator = "~*" if like_positive else "!~*"
+                                    sub_conditions.append(
+                                        rf"dou_inlabs.unaccent({key}) {operator} dou_inlabs.unaccent('\y{sub_term}\y')",
+                                    )
+
+                            key_conditions.append("(" + "".join(sub_conditions) + ")")
+
+                        else:
+                            key_conditions.append(
+                                rf"dou_inlabs.unaccent({key}) ~* dou_inlabs.unaccent('\y{term}\y')"
+                            )
+
+                    conditions.append("(" + " OR ".join(key_conditions) + ")")
+
+            elif key == "artcategory_ignore":
+                conditions.append(
+                    "("
+                    + " AND ".join(
+                        [
+                            rf"dou_inlabs.unaccent(artcategory) !~* dou_inlabs.unaccent('^{value}')"
+                            for value in values
+                        ]
+                    )
+                    + ")"
+                )
+            elif key == "terms_ignore":
+                conditions.append(
+                    "("
+                    + " AND ".join(
+                        [
+                            rf"dou_inlabs.unaccent(texto) !~* dou_inlabs.unaccent('\y{value}\y')"
+                            for value in values
+                        ]
+                    )
+                    + ")"
+                )
+            else:
+                conditions.append(
+                    "("
+                    + " OR ".join(
+                        [
+                            rf"dou_inlabs.unaccent({key}) ~* dou_inlabs.unaccent('\y{value}\y')"
+                            for value in values
+                        ]
+                    )
+                    + ")"
+                )
+
+        if conditions:
+            query = f"{query} AND {' AND '.join(conditions)}"
+
+        logging.info("Generated SQL Query:")
+        logging.info(query)
+
+        return {
+            "create_extension": "CREATE EXTENSION IF NOT EXISTS unaccent SCHEMA dou_inlabs",
+            "select": query,
+        }

--- a/src/utils/open_search/config.py
+++ b/src/utils/open_search/config.py
@@ -9,6 +9,12 @@ from airflow.models import Variable
 
 # Try to load OpenSearch connection parameters from Airflow Variables, falling
 # back to environment variables if not set in Airflow.
+
+RO_DOU_INLABS_USE_OPENSEARCH = Variable.get(
+    "RO_DOU_INLABS_USE_OPENSEARCH",
+    default_var=os.getenv("RO_DOU_INLABS_USE_OPENSEARCH", False),
+)
+
 OPENSEARCH_HOST = Variable.get(
     "OPENSEARCH_HOST",
     default_var=os.getenv("OPENSEARCH_HOST", "http://localhost:9200"),


### PR DESCRIPTION
Adiciona suporte para alternar o backend das buscas INLABS entre SQL ou Opensearch via variável do airflow RO_DOU_INLABS_USE_OPENSEARCH.
- Quando a flag está desabilitada (padrão), o fluxo usa o modo legado SQL em inlabs_hook_sql_mode.py. 
- Quando habilitada, usa o fluxo de indexação com OpenSearch. 
- A DAG de carga INLABS também passa a executar a task de indexação apenas quando OpenSearch estiver ativo.

TODO: Atualizar documentação