### PR TITLE
Incluir as variáveis do OpenSearch no target create-opensearch-variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ create-inlabs-portal-connection:
 		fi"
 
 create-opensearch-variable:
-	@echo "Creating 'opensearch' Airflow variable"
+	@echo "Creating 'opensearch' Airflow variables"
 	@docker exec airflow-webserver sh -c \
 		"if ! curl -f -s -LI 'http://localhost:8080/api/v1/variables/ro_dou_inlabs_use_opensearch' --user \"airflow:airflow\" > /dev/null; \
 		then \
@@ -142,6 +142,45 @@ create-opensearch-variable:
 			-d '{ \
 			\"key\": \"RO_DOU_INLABS_USE_OPENSEARCH\", \
 			\"value\": \"False\" \
+			}' > /dev/null; \
+		fi"
+	@docker exec airflow-webserver sh -c \
+		"if ! curl -f -s -LI 'http://localhost:8080/api/v1/variables/opensearch_host' --user \"airflow:airflow\" > /dev/null; \
+		then \
+			curl -s -X 'POST' \
+			'http://localhost:8080/api/v1/variables' \
+			-H 'accept: application/json' \
+			-H 'Content-Type: application/json' \
+			--user \"airflow:airflow\" \
+			-d '{ \
+			\"key\": \"OPENSEARCH_HOST\", \
+			\"value\": \"http://opensearch:9200\" \
+			}' > /dev/null; \
+		fi"
+	@docker exec airflow-webserver sh -c \
+		"if ! curl -f -s -LI 'http://localhost:8080/api/v1/variables/opensearch_user' --user \"airflow:airflow\" > /dev/null; \
+		then \
+			curl -s -X 'POST' \
+			'http://localhost:8080/api/v1/variables' \
+			-H 'accept: application/json' \
+			-H 'Content-Type: application/json' \
+			--user \"airflow:airflow\" \
+			-d '{ \
+			\"key\": \"OPENSEARCH_USER\", \
+			\"value\": \"OPENSEARCH_USER\" \
+			}' > /dev/null; \
+		fi"
+	@docker exec airflow-webserver sh -c \
+		"if ! curl -f -s -LI 'http://localhost:8080/api/v1/variables/opensearch_pass' --user \"airflow:airflow\" > /dev/null; \
+		then \
+			curl -s -X 'POST' \
+			'http://localhost:8080/api/v1/variables' \
+			-H 'accept: application/json' \
+			-H 'Content-Type: application/json' \
+			--user \"airflow:airflow\" \
+			-d '{ \
+			\"key\": \"OPENSEARCH_PASS\", \
+			\"value\": \"OPENSEARCH_PASS\" \
 			}' > /dev/null; \
 		fi"
 


### PR DESCRIPTION
## Descrição

O target `create-opensearch-variable` do `Makefile` criava apenas a variável `RO_DOU_INLABS_USE_OPENSEARCH`.

Esta alteração adiciona a criação das variáveis:

* `OPENSEARCH_HOST`
* `OPENSEARCH_USER`
* `OPENSEARCH_PASS`

A implementação segue o mesmo padrão de verificação (*guard*) com `curl` já utilizado para a variável `RO_DOU_INLABS_USE_OPENSEARCH`, evitando a recriação de variáveis que já existam.
