### PR TITLE
POC: gerador de YAML de configuração de DAGs via CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,3 +268,7 @@ down:
 .PHONY: tests
 tests:
 	docker exec airflow-webserver sh -c "cd /opt/airflow/tests/ && pytest -vvv --color=yes"
+
+.PHONY: gerador-cli
+gerador-cli:
+	docker exec -it airflow-webserver python3 /opt/airflow/tools/gerador_cli.py

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ tests:
 	docker exec airflow-webserver sh -c "cd /opt/airflow/tests/ && pytest -vvv --color=yes"
 
 # Roda o gerador de YAML dentro do container, onde o Airflow está
-# disponível; -it porque o modo interativo lê do terminal.
+# disponível; -it porque o gerador lê as respostas do terminal.
 .PHONY: gerador-cli
 gerador-cli:
 	docker exec -it airflow-webserver python3 /opt/airflow/tools/gerador_cli.py

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,6 @@ tests:
 	docker exec airflow-webserver sh -c "cd /opt/airflow/tests/ && pytest -vvv --color=yes"
 
 #PYTHONWARNINGS=ignore evita deprecation warnings do próprio Airflow poluindo o terminal interativo.
-.PHONY: gerador-cli
-gerador-cli:
+.PHONY: gerar-yml
+gerar-yml:
 	docker exec -it -e PYTHONWARNINGS=ignore airflow-webserver python3 /opt/airflow/tools/gerador_cli.py

--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,8 @@ down:
 tests:
 	docker exec airflow-webserver sh -c "cd /opt/airflow/tests/ && pytest -vvv --color=yes"
 
+# Roda o gerador de YAML dentro do container, onde o Airflow está
+# disponível; -it porque o modo interativo lê do terminal.
 .PHONY: gerador-cli
 gerador-cli:
 	docker exec -it airflow-webserver python3 /opt/airflow/tools/gerador_cli.py

--- a/Makefile
+++ b/Makefile
@@ -269,8 +269,7 @@ down:
 tests:
 	docker exec airflow-webserver sh -c "cd /opt/airflow/tests/ && pytest -vvv --color=yes"
 
-# Roda o gerador de YAML dentro do container, onde o Airflow está
-# disponível; -it porque o gerador lê as respostas do terminal.
+#PYTHONWARNINGS=ignore evita deprecation warnings do próprio Airflow poluindo o terminal interativo.
 .PHONY: gerador-cli
 gerador-cli:
-	docker exec -it airflow-webserver python3 /opt/airflow/tools/gerador_cli.py
+	docker exec -it -e PYTHONWARNINGS=ignore airflow-webserver python3 /opt/airflow/tools/gerador_cli.py

--- a/Makefile
+++ b/Makefile
@@ -272,4 +272,9 @@ tests:
 #PYTHONWARNINGS=ignore evita deprecation warnings do próprio Airflow poluindo o terminal interativo.
 .PHONY: gerar-yml
 gerar-yml:
+	@docker inspect -f '{{.State.Running}}' airflow-webserver >/dev/null 2>&1 || { \
+		echo "Erro: o container airflow-webserver não está rodando."; \
+		echo "Suba o ambiente primeiro com: make run"; \
+		exit 1; \
+	}
 	docker exec -it -e PYTHONWARNINGS=ignore airflow-webserver python3 /opt/airflow/tools/gerador_cli.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ x-airflow-common: &airflow-common
     - ./dag_load_inlabs:/opt/airflow/dags/dag_load_inlabs
     - ./tests:/opt/airflow/tests # for test purpose
     - ./schemas:/opt/airflow/schemas # for test purpose
+    - ./tools:/opt/airflow/tools # for development purpose
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     postgres:

--- a/docs/docs/como_funciona/parametros.md
+++ b/docs/docs/como_funciona/parametros.md
@@ -2,7 +2,7 @@
 
 A página abaixo lista os parâmetros configuráveis nos arquivos YAML:
 
-O Ro-DOU também oferece duas ferramentas para montar o arquivo sem editá-lo manualmente: o [Gerador de configuração (YAML)](../gerador_yaml.html), um formulário guiado no navegador com explicação de cada campo, e o comando `make gerador-cli`, para quem já tem o Ro-DOU [instalado](../como_utilizar/instalacao.md).
+O Ro-DOU também oferece duas ferramentas para montar o arquivo sem editá-lo manualmente: o [Gerador de configuração (YAML)](../gerador_yaml.html), um formulário guiado no navegador com explicação de cada campo, e o comando `make gerar-yml`, para quem já tem o Ro-DOU [instalado](../como_utilizar/instalacao.md).
 
 ## Parâmetros da DAG
 * **id** *(obrigatório)*: Nome identificador da DAG a ser gerada. Deve ser único.

--- a/docs/docs/como_funciona/parametros.md
+++ b/docs/docs/como_funciona/parametros.md
@@ -2,7 +2,7 @@
 
 A página abaixo lista os parâmetros configuráveis nos arquivos YAML:
 
-O Ro-DOU também oferece o [Gerador de configuração (YAML)](../gerador_yaml.html), que permite montar o arquivo em um formulário guiado, com validações e explicação de cada campo.
+O Ro-DOU também oferece duas ferramentas para montar o arquivo sem editá-lo manualmente: o [Gerador de configuração (YAML)](../gerador_yaml.html), um formulário guiado no navegador com explicação de cada campo, e o comando `make gerador-cli`, para quem já tem o Ro-DOU [instalado](../como_utilizar/instalacao.md).
 
 ## Parâmetros da DAG
 * **id** *(obrigatório)*: Nome identificador da DAG a ser gerada. Deve ser único.

--- a/docs/docs/como_utilizar/instalacao.md
+++ b/docs/docs/como_utilizar/instalacao.md
@@ -81,7 +81,7 @@ O Apache Airflow, utilizado também para executar o Ro-DOU, pode levar alguns mi
 
 Na tela inicial do Airflow, são fornecidos clippings de exemplo. A partir dos arquivos YAML (.yaml) do diretório `dag_confs/`, é possível manipular e customizar as pesquisas de clipping desejadas nos diários oficiais. Dentro dos arquivos YAML, é possível, por exemplo, definir palavras-chave de busca e um endereço de e-mail para recebimento de uma mensagem com os resultados da busca no(s) diário(s) oficial(is).
 
-Para criar um novo arquivo YAML de pesquisa sem precisar editá-lo manualmente, utilize o [Gerador de configuração (YAML)](../gerador_yaml.html). Alternativamente, com o ambiente rodando, execute `make gerador-cli` no terminal: ele pergunta os campos passo a passo, valida com as mesmas regras do Ro-DOU e salva o arquivo direto em `dag_confs/`.
+Para criar um novo arquivo YAML de pesquisa sem precisar editá-lo manualmente, utilize o [Gerador de configuração (YAML)](../gerador_yaml.html). Alternativamente, com o ambiente rodando, execute `make gerar-yml` no terminal: ele pergunta os campos passo a passo, valida com as mesmas regras do Ro-DOU e salva o arquivo direto em `dag_confs/`.
 
 Para executar qualquer DAG do Airflow, é necessário ligá-la. Inicialmente, todas as DAGs ficam pausadas por padrão. Sugerimos começar testando o clipping **all_parameters_example**. Utilize o botão _toggle_ para ligá-lo. Após ativá-lo, o Airflow executará a DAG uma única vez. Clique no [nome da DAG](http://localhost:8080/tree?dag_id=all_parameters_example)
 para visualizar o detalhe da execução.

--- a/docs/docs/como_utilizar/instalacao.md
+++ b/docs/docs/como_utilizar/instalacao.md
@@ -81,7 +81,7 @@ O Apache Airflow, utilizado também para executar o Ro-DOU, pode levar alguns mi
 
 Na tela inicial do Airflow, são fornecidos clippings de exemplo. A partir dos arquivos YAML (.yaml) do diretório `dag_confs/`, é possível manipular e customizar as pesquisas de clipping desejadas nos diários oficiais. Dentro dos arquivos YAML, é possível, por exemplo, definir palavras-chave de busca e um endereço de e-mail para recebimento de uma mensagem com os resultados da busca no(s) diário(s) oficial(is).
 
-Para criar um novo arquivo YAML de pesquisa sem precisar editá-lo manualmente, utilize o [Gerador de configuração (YAML)](../gerador_yaml.html).
+Para criar um novo arquivo YAML de pesquisa sem precisar editá-lo manualmente, utilize o [Gerador de configuração (YAML)](../gerador_yaml.html). Alternativamente, com o ambiente rodando, execute `make gerador-cli` no terminal: ele pergunta os campos passo a passo, valida com as mesmas regras do Ro-DOU e salva o arquivo direto em `dag_confs/`.
 
 Para executar qualquer DAG do Airflow, é necessário ligá-la. Inicialmente, todas as DAGs ficam pausadas por padrão. Sugerimos começar testando o clipping **all_parameters_example**. Utilize o botão _toggle_ para ligá-lo. Após ativá-lo, o Airflow executará a DAG uma única vez. Clique no [nome da DAG](http://localhost:8080/tree?dag_id=all_parameters_example)
 para visualizar o detalhe da execução.

--- a/docs/docs/outros/faq.md
+++ b/docs/docs/outros/faq.md
@@ -6,7 +6,7 @@ Nesta seção, você encontrará perguntas e respostas comuns e solução de pro
 As instruções detalhadas de instalação estão [neste link](https://gestaogovbr.github.io/Ro-dou/como_utilizar/instalacao/).
 
 1. **Como configurar os parâmetros de pesquisa do Ro-DOU?** <br>
-Os parâmetros devem ser editados no arquivo em formato yml. Você pode montar esse arquivo de forma guiada, sem editá-lo manualmente, usando o [Gerador de configuração (YAML)](https://gestaogovbr.github.io/Ro-dou/gerador_yaml.html).
+Os parâmetros devem ser editados no arquivo em formato yml. Você pode montar esse arquivo de forma guiada, sem editá-lo manualmente, de duas formas: pelo [Gerador de configuração (YAML)](https://gestaogovbr.github.io/Ro-dou/gerador_yaml.html), direto no navegador, ou — se já tiver o Ro-DOU [instalado](https://gestaogovbr.github.io/Ro-dou/como_utilizar/instalacao/) — pelo comando `make gerador-cli`, que valida e salva o arquivo direto em `dag_confs/`.
 
 1. **Qual a configuração mínima para a instalação do Ro-DOU?** <br>
 É recomendado 4 Gb de memória RAM e 2 Gb de espaço em disco pelo menos.

--- a/docs/docs/outros/faq.md
+++ b/docs/docs/outros/faq.md
@@ -6,7 +6,7 @@ Nesta seção, você encontrará perguntas e respostas comuns e solução de pro
 As instruções detalhadas de instalação estão [neste link](https://gestaogovbr.github.io/Ro-dou/como_utilizar/instalacao/).
 
 1. **Como configurar os parâmetros de pesquisa do Ro-DOU?** <br>
-Os parâmetros devem ser editados no arquivo em formato yml. Você pode montar esse arquivo de forma guiada, sem editá-lo manualmente, de duas formas: pelo [Gerador de configuração (YAML)](https://gestaogovbr.github.io/Ro-dou/gerador_yaml.html), direto no navegador, ou — se já tiver o Ro-DOU [instalado](https://gestaogovbr.github.io/Ro-dou/como_utilizar/instalacao/) — pelo comando `make gerador-cli`, que valida e salva o arquivo direto em `dag_confs/`.
+Os parâmetros devem ser editados no arquivo em formato yml. Você pode montar esse arquivo de forma guiada, sem editá-lo manualmente, de duas formas: pelo [Gerador de configuração (YAML)](https://gestaogovbr.github.io/Ro-dou/gerador_yaml.html), direto no navegador, ou — se já tiver o Ro-DOU [instalado](https://gestaogovbr.github.io/Ro-dou/como_utilizar/instalacao/) — pelo comando `make gerar-yml`, que valida e salva o arquivo direto em `dag_confs/`.
 
 1. **Qual a configuração mínima para a instalação do Ro-DOU?** <br>
 É recomendado 4 Gb de memória RAM e 2 Gb de espaço em disco pelo menos.

--- a/tests/gerador_cli_test.py
+++ b/tests/gerador_cli_test.py
@@ -37,6 +37,9 @@ def test_modo_interativo_gera_yaml_valido():
             "",  # fonte (pula; usa DOU)
             "dados abertos, governo aberto",  # termos
             "destination@economia.gov.br",  # e-mails
+            "",  # subject (pula)
+            "",  # attach_csv (pula; default não)
+            "",  # skip_null (pula; default sim)
         ]
     ) + "\n"
     resultado = subprocess.run(

--- a/tests/gerador_cli_test.py
+++ b/tests/gerador_cli_test.py
@@ -1,0 +1,47 @@
+"""Testa o CLI (POC) de geração de YAML: tools/gerador_cli.py."""
+
+import os
+import subprocess
+import sys
+
+import yaml
+
+# add module path so we can import from other modules
+_TESTS_DIR = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, _TESTS_DIR)
+from schemas import RoDouConfig
+
+# Airflow layout (Docker) and repo-root layout (dev / mount).
+_CLI_PATHS = [
+    "/opt/airflow/tools/gerador_cli.py",
+    os.path.normpath(os.path.join(_TESTS_DIR, "..", "tools", "gerador_cli.py")),
+]
+_SRC_PATHS = [
+    "/opt/airflow/dags/ro_dou_src",
+    os.path.normpath(os.path.join(_TESTS_DIR, "..", "src")),
+]
+
+
+def test_modo_flags_gera_yaml_valido():
+    cli = next(path for path in _CLI_PATHS if os.path.exists(path))
+    src = next(path for path in _SRC_PATHS if os.path.isdir(path))
+    resultado = subprocess.run(
+        [
+            sys.executable, cli,
+            "--id", "teste_poc_cli",
+            "--description", "Teste do modo por flags do gerador CLI",
+            "--terms", "dados abertos",
+            "--terms", "governo aberto",
+            "--emails", "destination@economia.gov.br",
+            "--stdout",
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "RO_DOU_SRC_PATH": src},
+        check=False,
+    )
+    assert resultado.returncode == 0, resultado.stderr
+    data = yaml.safe_load(resultado.stdout)
+    config = RoDouConfig(**data)
+    assert config.dag.id == "teste_poc_cli"
+    assert config.dag.search[0].terms == ["dados abertos", "governo aberto"]

--- a/tests/gerador_cli_test.py
+++ b/tests/gerador_cli_test.py
@@ -34,8 +34,11 @@ def test_modo_interativo_gera_yaml_valido():
             "Teste do modo interativo do gerador CLI",  # description
             "",  # schedule (pula)
             "",  # owner (pula)
+            "",  # callback (pula)
             "",  # fonte (pula; usa DOU)
             "dados abertos, governo aberto",  # termos
+            "",  # terms_ignore (pula)
+            "",  # dou_sections (pula; default TODOS)
             "destination@economia.gov.br",  # e-mails
             "",  # subject (pula)
             "",  # attach_csv (pula; default não)

--- a/tests/gerador_cli_test.py
+++ b/tests/gerador_cli_test.py
@@ -1,6 +1,7 @@
 """Testa o CLI (POC) de geração de YAML: tools/gerador_cli.py."""
 
 import os
+import re
 import subprocess
 import sys
 
@@ -21,27 +22,35 @@ _SRC_PATHS = [
     os.path.normpath(os.path.join(_TESTS_DIR, "..", "src")),
 ]
 
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
-def test_modo_flags_gera_yaml_valido():
+
+def test_modo_interativo_gera_yaml_valido():
     cli = next(path for path in _CLI_PATHS if os.path.exists(path))
     src = next(path for path in _SRC_PATHS if os.path.isdir(path))
-    resultado = subprocess.run(
+    respostas = "\n".join(
         [
-            sys.executable, cli,
-            "--id", "teste_poc_cli",
-            "--description", "Teste do modo por flags do gerador CLI",
-            "--terms", "dados abertos",
-            "--terms", "governo aberto",
-            "--emails", "destination@economia.gov.br",
-            "--stdout",
-        ],
+            "teste_poc_cli",  # id
+            "Teste do modo interativo do gerador CLI",  # description
+            "",  # schedule (pula)
+            "",  # owner (pula)
+            "",  # fonte (pula; usa DOU)
+            "dados abertos, governo aberto",  # termos
+            "destination@economia.gov.br",  # e-mails
+        ]
+    ) + "\n"
+    resultado = subprocess.run(
+        [sys.executable, cli, "--stdout"],
+        input=respostas,
         capture_output=True,
         text=True,
         env={**os.environ, "RO_DOU_SRC_PATH": src},
         check=False,
     )
     assert resultado.returncode == 0, resultado.stderr
-    data = yaml.safe_load(resultado.stdout)
+    saida = _ANSI.sub("", resultado.stdout)
+    yaml_texto = saida.split("── YAML gerado ──\n", 1)[1]
+    data = yaml.safe_load(yaml_texto)
     config = RoDouConfig(**data)
     assert config.dag.id == "teste_poc_cli"
     assert config.dag.search[0].terms == ["dados abertos", "governo aberto"]

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -319,6 +319,15 @@ def salvar_arquivo(
     try:
         with open(caminho, "w", encoding="utf-8") as arquivo:
             arquivo.write(yaml_texto)
+    except PermissionError:
+        print(
+            f"{VERM}Permissão negada para gravar em {caminho}.\n"
+            f"Na raiz do projeto (fora do container), rode:\n"
+            f"  chmod 777 dag_confs\n"
+            f"E tente de novo. Se persistir, use --stdout.{RESET}",
+            file=sys.stderr,
+        )
+        return 1
     except OSError as exc:
         print(
             f"{VERM}Não foi possível salvar em {caminho} ({exc.strerror}). "

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -50,6 +50,16 @@ def perguntar(
     while True:
         valor = input(f"{marca} {mensagem}: ").strip()
         if valor:
+            # Glitches raros de terminal cortam acentos ao meio; sem isso,
+            # o valor corrompido seguiria em frente sem avisar ninguém.
+            try:
+                valor.encode("utf-8")
+            except UnicodeEncodeError:
+                print(
+                    f"{VERM}  ! Caractere inválido (acento corrompido ao "
+                    f"digitar). Digite novamente.{RESET}"
+                )
+                continue
             return valor
         if not obrigatorio:
             return None

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -113,16 +113,29 @@ def coletar_owner() -> list[str] | None:
     return perguntar_lista("Owners/responsáveis pela DAG", dica="ex.: cginf")
 
 
+def coletar_callback() -> dict | None:
+    """Pergunta os e-mails avisados se a busca falhar (bloco `callback`)."""
+    emails = perguntar_lista(
+        "E-mails avisados se a busca falhar", dica="ex.: admin@orgao.gov.br"
+    )
+    if not emails:
+        return None
+    return {"on_failure_callback": emails}
+
+
 CAMPOS_SIMPLES = {
     "id": coletar_id,
     "description": coletar_description,
     "schedule": coletar_schedule,
     "owner": coletar_owner,
+    "callback": coletar_callback,
 }
 
 
 def coletar_search() -> dict:
-    """Pergunta o bloco `search`: fonte, termos e territory_id (se QD)."""
+    """Pergunta o bloco `search`: fonte, termos, termos a ignorar, seções do
+    Diário (se DOU/INLABS), territory_id (se QD) e opções de exibição
+    exclusivas do INLABS (se INLABS)."""
     titulo("Busca")
     search = {}
     fonte = perguntar("Fonte (DOU, INLABS ou QD)", dica="apenas uma; Enter usa DOU")
@@ -133,6 +146,19 @@ def coletar_search() -> dict:
     )
     if terms:
         search["terms"] = terms
+    terms_ignore = perguntar_lista(
+        "Termos a ignorar na pesquisa", dica="ex.: revogado, sem efeito"
+    )
+    if terms_ignore:
+        search["terms_ignore"] = terms_ignore
+    if "QD" not in search.get("sources", []):
+        dou_sections = perguntar_lista(
+            "Seções do Diário a procurar",
+            dica="ex.: SECAO_1, SECAO_3 — Enter usa TODOS "
+            "(outros valores: SECAO_2, EDICAO_EXTRA, EDICAO_SUPLEMENTAR)",
+        )
+        if dou_sections:
+            search["dou_sections"] = [secao.upper() for secao in dou_sections]
     if "QD" in search.get("sources", []):
         territory_id = perguntar(
             "ID do município no Querido Diário (territory_id)",
@@ -140,6 +166,16 @@ def coletar_search() -> dict:
         )
         if territory_id:
             search["territory_id"] = territory_id
+    if "INLABS" in search.get("sources", []):
+        search["full_text"] = perguntar_sim_nao(
+            "Mostrar o texto completo da publicação no relatório?", default=False
+        )
+        search["use_summary"] = perguntar_sim_nao(
+            "Mostrar a ementa oficial, quando existir?", default=False
+        )
+        search["show_relevancy"] = perguntar_sim_nao(
+            "Mostrar a relevância de cada resultado?", default=False
+        )
     return search
 
 

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -42,12 +42,14 @@ FONTES = {"dou": "DOU", "inlabs": "INLABS", "qd": "QD"}
 # ---------------------------------------------------------------- interação
 
 def titulo(texto: str) -> None:
+    """Imprime um cabeçalho de seção colorido."""
     print(f"\n{AZUL}── {texto} ──{RESET}")
 
 
 def perguntar(
     mensagem: str, dica: str | None = None, obrigatorio: bool = False
 ) -> str | None:
+    """Faz uma pergunta de texto livre; insiste se obrigatória e vazia."""
     if dica:
         print(f"{CINZA}{dica}{RESET}")
     marca = f"{VERM}*{RESET}" if obrigatorio else " "
@@ -63,6 +65,7 @@ def perguntar(
 def perguntar_lista(
     mensagem: str, dica: str | None = None, obrigatorio: bool = False
 ) -> list[str] | None:
+    """Pergunta uma lista de valores separados por vírgula."""
     valor = perguntar(f"{mensagem} (separe por vírgula)", dica, obrigatorio)
     if not valor:
         return None
@@ -70,6 +73,7 @@ def perguntar_lista(
 
 
 def perguntar_sim_nao(mensagem: str, default: bool = True) -> bool:
+    """Pergunta sim/não; Enter usa o default."""
     dica = "S/n" if default else "s/N"
     while True:
         valor = input(f"  {mensagem} ({dica}): ").strip().lower()
@@ -85,6 +89,7 @@ def perguntar_sim_nao(mensagem: str, default: bool = True) -> bool:
 # ------------------------------------------------------- coleta interativa
 
 def coletar_id() -> str:
+    """Pergunta o id da DAG (obrigatório)."""
     return perguntar(
         "ID da DAG",
         dica="ex.: monitoramento_dados_abertos (único, sem espaços)",
@@ -93,6 +98,7 @@ def coletar_id() -> str:
 
 
 def coletar_description() -> str:
+    """Pergunta a descrição da DAG (obrigatória)."""
     return perguntar(
         "Descrição da DAG",
         dica="ex.: Monitora publicações sobre dados abertos no DOU",
@@ -101,6 +107,7 @@ def coletar_description() -> str:
 
 
 def coletar_schedule() -> str | None:
+    """Pergunta o agendamento cron (opcional)."""
     return perguntar(
         "Agendamento cron",
         dica="ex.: 0 8 * * MON-FRI — Enter usa o padrão do Ro-dou",
@@ -108,6 +115,7 @@ def coletar_schedule() -> str | None:
 
 
 def coletar_owner() -> list[str] | None:
+    """Pergunta os owners da DAG (opcional)."""
     return perguntar_lista("Owners/responsáveis pela DAG", dica="ex.: cginf")
 
 
@@ -120,6 +128,7 @@ CAMPOS_SIMPLES = {
 
 
 def coletar_search() -> dict:
+    """Pergunta o bloco `search`: fontes, termos e territory_id (se QD)."""
     titulo("Busca")
     search = {}
     sources = perguntar_lista("Fontes (DOU, INLABS, QD)", dica="Enter usa DOU")
@@ -141,6 +150,7 @@ def coletar_search() -> dict:
 
 
 def coletar_report() -> dict:
+    """Pergunta o bloco `report`: e-mails de destino."""
     titulo("Relatório")
     report = {}
     emails = perguntar_lista(
@@ -154,7 +164,10 @@ def coletar_report() -> dict:
 # ------------------------------------------------------------- validação
 
 def formatar_erros(exc: ValidationError) -> str:
+    """Converte um ValidationError do Pydantic em lista legível de erros."""
     erros = exc.errors()
+    # Quando um validator do schema levanta ValueError, o Pydantic também
+    # reporta erros de tipo dos outros ramos da união; mostra só as regras.
     erros_de_regra = [erro for erro in erros if erro["type"] == "value_error"]
     if erros_de_regra:
         erros = erros_de_regra
@@ -203,7 +216,12 @@ class DumperIndentado(yaml.SafeDumper):
 
 
 def gerar_yaml(config: RoDouConfig) -> str:
+    """Serializa a configuração validada em YAML enxuto."""
+    # Só o que o usuário informou entra no YAML; os defaults ficam a cargo
+    # do Ro-dou na hora de carregar a DAG.
     dag_enxuto = config.dag.model_dump(exclude_defaults=True, exclude_none=True)
+    # O schema normaliza `search` para lista, mas com uma busca só os
+    # exemplos de dag_confs/ usam mapeamento direto.
     search = dag_enxuto.get("search")
     if isinstance(search, list) and len(search) == 1:
         dag_enxuto["search"] = search[0]
@@ -220,6 +238,7 @@ RE_ITEM = re.compile(r"^\s*- ")
 
 
 def colorir_yaml(texto: str) -> str:
+    """Aplica cores ANSI ao YAML para exibição no terminal."""
     linhas = []
     for linha in texto.splitlines():
         chave = RE_CHAVE.match(linha)
@@ -238,6 +257,7 @@ def colorir_yaml(texto: str) -> str:
 def salvar_arquivo(
     id_dag: str, yaml_texto: str, args: argparse.Namespace, interativo: bool
 ) -> int:
+    """Grava o YAML em disco, protegendo contra sobrescrita acidental."""
     caminho = args.output or os.path.join(DAG_CONFS_DIR, f"{id_dag}.yaml")
     if os.path.exists(caminho) and not args.force:
         if not interativo:
@@ -269,6 +289,7 @@ def salvar_arquivo(
 # ------------------------------------------------------------------ modos
 
 def modo_interativo(args: argparse.Namespace) -> int:
+    """Coleta os campos por perguntas, valida e repergunta só o que falhou."""
     print(f"{AZUL}Gerador de YAML do Ro-dou{RESET}")
     print(
         f"{CINZA}Responda às perguntas abaixo; campos marcados com "
@@ -298,6 +319,7 @@ def modo_interativo(args: argparse.Namespace) -> int:
                 if campo in CAMPOS_SIMPLES:
                     valor = CAMPOS_SIMPLES[campo]()
                     if valor is None:
+                        # Enter em campo opcional descarta o valor que falhou.
                         dag_dict.pop(campo, None)
                     else:
                         dag_dict[campo] = valor
@@ -318,6 +340,7 @@ def modo_interativo(args: argparse.Namespace) -> int:
 
 
 def montar_dag_dict(args: argparse.Namespace) -> dict:
+    """Traduz as flags do argparse para o dict esperado pelo schema."""
     search = {}
     if args.sources:
         search["sources"] = [FONTES[fonte] for fonte in args.sources]
@@ -339,6 +362,7 @@ def montar_dag_dict(args: argparse.Namespace) -> dict:
 
 
 def modo_direto(args: argparse.Namespace) -> int:
+    """Gera o YAML a partir das flags, sem perguntas; erro vira exit 1."""
     try:
         config = RoDouConfig(dag=montar_dag_dict(args))
     except ValidationError as exc:
@@ -354,6 +378,8 @@ def modo_direto(args: argparse.Namespace) -> int:
 
 # ------------------------------------------------------------------- main
 
+# Flags de conteúdo: a presença de qualquer uma delas ativa o modo direto.
+# --output/--stdout/--force ficam de fora porque valem nos dois modos.
 FLAGS_CONFIG = (
     "id", "description", "schedule", "owner",
     "terms", "sources", "territory_id", "emails",
@@ -361,6 +387,7 @@ FLAGS_CONFIG = (
 
 
 def montar_parser() -> argparse.ArgumentParser:
+    """Define as flags aceitas pela linha de comando."""
     parser = argparse.ArgumentParser(
         description="Gera arquivos YAML de configuração de DAGs do Ro-dou. "
         "Sem flags de configuração, roda em modo interativo.",
@@ -406,6 +433,7 @@ def montar_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Escolhe o modo: flags de conteúdo presentes → direto; senão interativo."""
     args = montar_parser().parse_args(argv)
     modo_flags = any(
         getattr(args, campo) is not None for campo in FLAGS_CONFIG

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -22,7 +22,7 @@ from pydantic import ValidationError
 
 SRC_PATH = os.environ.get("RO_DOU_SRC_PATH", "/opt/airflow/dags/ro_dou_src")
 sys.path.insert(0, SRC_PATH)
-from schemas import RoDouConfig  # noqa: E402
+from schemas import RoDouConfig  
 
 DAG_CONFS_DIR = os.environ.get(
     "RO_DOU__DAG_CONF_DIR", "/opt/airflow/dags/ro_dou/dag_confs"
@@ -144,7 +144,7 @@ def coletar_search() -> dict:
 
 
 def coletar_report() -> dict:
-    """Pergunta o bloco `report`: e-mails de destino."""
+    """Pergunta o bloco `report`: e-mails de destino, assunto e opções de envio."""
     titulo("Relatório")
     report = {}
     emails = perguntar_lista(
@@ -152,6 +152,17 @@ def coletar_report() -> dict:
     )
     if emails:
         report["emails"] = emails
+    subject = perguntar(
+        "Assunto do e-mail", dica="ex.: Alerta Ro-DOU — Dados abertos"
+    )
+    if subject:
+        report["subject"] = subject
+    report["attach_csv"] = perguntar_sim_nao(
+        "Anexar CSV com os resultados?", default=False
+    )
+    report["skip_null"] = perguntar_sim_nao(
+        "Pular o envio quando não houver resultados?", default=True
+    )
     return report
 
 

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -1,11 +1,7 @@
 """CLI (POC) para gerar arquivos de configuração YAML do Ro-dou.
 
-Dois modos de uso:
-
-- interativo (padrão, sem flags de configuração): perguntas passo a passo;
-- por flags: geração direta, sem perguntas — ex.:
-  ``gerador_cli.py --id minha_busca --description "..." --terms "dados abertos"
-  --emails pessoa@gov.br --stdout``
+O uso é interativo: o gerador faz perguntas passo a passo e, ao final,
+salva o YAML em `dag_confs/` (ou o imprime na tela, com ``--stdout``).
 
 Este script não reimplementa nenhuma regra de negócio: toda a validação é
 delegada ao `RoDouConfig` (Pydantic) definido em `src/schemas.py`, a mesma
@@ -35,8 +31,6 @@ DAG_CONFS_DIR = os.environ.get(
 VERDE, AZUL, VERM, CINZA, RESET = (
     "\033[32m", "\033[36m", "\033[31m", "\033[90m", "\033[0m"
 )
-
-FONTES = {"dou": "DOU", "inlabs": "INLABS", "qd": "QD"}
 
 
 # ---------------------------------------------------------------- interação
@@ -128,12 +122,12 @@ CAMPOS_SIMPLES = {
 
 
 def coletar_search() -> dict:
-    """Pergunta o bloco `search`: fontes, termos e territory_id (se QD)."""
+    """Pergunta o bloco `search`: fonte, termos e territory_id (se QD)."""
     titulo("Busca")
     search = {}
-    sources = perguntar_lista("Fontes (DOU, INLABS, QD)", dica="Enter usa DOU")
-    if sources:
-        search["sources"] = [fonte.upper() for fonte in sources]
+    fonte = perguntar("Fonte (DOU, INLABS ou QD)", dica="apenas uma; Enter usa DOU")
+    if fonte:
+        search["sources"] = [fonte.upper()]
     terms = perguntar_lista(
         "Termos de pesquisa", dica="ex.: dados abertos, governo aberto"
     )
@@ -255,18 +249,11 @@ def colorir_yaml(texto: str) -> str:
 # ------------------------------------------------------------------ saída
 
 def salvar_arquivo(
-    id_dag: str, yaml_texto: str, args: argparse.Namespace, interativo: bool
+    id_dag: str, yaml_texto: str, args: argparse.Namespace
 ) -> int:
     """Grava o YAML em disco, protegendo contra sobrescrita acidental."""
     caminho = args.output or os.path.join(DAG_CONFS_DIR, f"{id_dag}.yaml")
     if os.path.exists(caminho) and not args.force:
-        if not interativo:
-            print(
-                f"{VERM}Arquivo {caminho} já existe — use --force para "
-                f"sobrescrever.{RESET}",
-                file=sys.stderr,
-            )
-            return 1
         if not perguntar_sim_nao(
             f"Arquivo {caminho} já existe. Sobrescrever?", default=False
         ):
@@ -286,7 +273,7 @@ def salvar_arquivo(
     return 0
 
 
-# ------------------------------------------------------------------ modos
+# -------------------------------------------------------- modo interativo
 
 def modo_interativo(args: argparse.Namespace) -> int:
     """Coleta os campos por perguntas, valida e repergunta só o que falhou."""
@@ -336,86 +323,16 @@ def modo_interativo(args: argparse.Namespace) -> int:
     if not perguntar_sim_nao("Salvar este arquivo?"):
         print("Arquivo não foi salvo.")
         return 0
-    return salvar_arquivo(config.dag.id, yaml_texto, args, interativo=True)
-
-
-def montar_dag_dict(args: argparse.Namespace) -> dict:
-    """Traduz as flags do argparse para o dict esperado pelo schema."""
-    search = {}
-    if args.sources:
-        search["sources"] = [FONTES[fonte] for fonte in args.sources]
-    if args.terms:
-        search["terms"] = args.terms
-    if args.territory_id is not None:
-        search["territory_id"] = args.territory_id
-    report = {}
-    if args.emails:
-        report["emails"] = args.emails
-    dag_dict = {"search": search, "report": report}
-    for campo in ("id", "description", "schedule"):
-        valor = getattr(args, campo)
-        if valor is not None:
-            dag_dict[campo] = valor
-    if args.owner:
-        dag_dict["owner"] = args.owner
-    return dag_dict
-
-
-def modo_direto(args: argparse.Namespace) -> int:
-    """Gera o YAML a partir das flags, sem perguntas; erro vira exit 1."""
-    try:
-        config = RoDouConfig(dag=montar_dag_dict(args))
-    except ValidationError as exc:
-        print(f"{VERM}Configuração inválida:{RESET}", file=sys.stderr)
-        print(f"{VERM}{formatar_erros(exc)}{RESET}", file=sys.stderr)
-        return 1
-    yaml_texto = gerar_yaml(config)
-    if args.stdout:
-        print(yaml_texto, end="")
-        return 0
-    return salvar_arquivo(config.dag.id, yaml_texto, args, interativo=False)
+    return salvar_arquivo(config.dag.id, yaml_texto, args)
 
 
 # ------------------------------------------------------------------- main
 
-# Flags de conteúdo: a presença de qualquer uma delas ativa o modo direto.
-# --output/--stdout/--force ficam de fora porque valem nos dois modos.
-FLAGS_CONFIG = (
-    "id", "description", "schedule", "owner",
-    "terms", "sources", "territory_id", "emails",
-)
-
-
 def montar_parser() -> argparse.ArgumentParser:
-    """Define as flags aceitas pela linha de comando."""
+    """Define as flags de saída aceitas pela linha de comando."""
     parser = argparse.ArgumentParser(
-        description="Gera arquivos YAML de configuração de DAGs do Ro-dou. "
-        "Sem flags de configuração, roda em modo interativo.",
-        epilog="exemplo: %(prog)s --id minha_busca --description 'Minha busca' "
-        "--terms 'dados abertos' --emails pessoa@gov.br --stdout",
-    )
-    parser.add_argument("--id", help="nome único da DAG")
-    parser.add_argument("--description", help="descrição da DAG")
-    parser.add_argument("--schedule", help="expressão cron do agendamento")
-    parser.add_argument(
-        "--owner", action="append", metavar="NOME",
-        help="responsável pela DAG (repetível)",
-    )
-    parser.add_argument(
-        "--terms", action="append", metavar="TERMO",
-        help="termo de pesquisa (repetível)",
-    )
-    parser.add_argument(
-        "--sources", action="append", choices=sorted(FONTES),
-        help="fonte de dados (repetível; padrão: dou)",
-    )
-    parser.add_argument(
-        "--territory-id", type=int, metavar="ID",
-        help="ID do município no Querido Diário",
-    )
-    parser.add_argument(
-        "--emails", action="append", metavar="EMAIL",
-        help="e-mail de destino do relatório (repetível)",
+        description="Gera arquivos YAML de configuração de DAGs do Ro-dou "
+        "por meio de perguntas interativas.",
     )
     parser.add_argument(
         "--output", metavar="ARQUIVO",
@@ -433,13 +350,8 @@ def montar_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Escolhe o modo: flags de conteúdo presentes → direto; senão interativo."""
+    """Processa as flags de saída e roda o questionário interativo."""
     args = montar_parser().parse_args(argv)
-    modo_flags = any(
-        getattr(args, campo) is not None for campo in FLAGS_CONFIG
-    )
-    if modo_flags:
-        return modo_direto(args)
     return modo_interativo(args)
 
 

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -1,0 +1,423 @@
+"""CLI (POC) para gerar arquivos de configuração YAML do Ro-dou.
+
+Dois modos de uso:
+
+- interativo (padrão, sem flags de configuração): perguntas passo a passo;
+- por flags: geração direta, sem perguntas — ex.:
+  ``gerador_cli.py --id minha_busca --description "..." --terms "dados abertos"
+  --emails pessoa@gov.br --stdout``
+
+Este script não reimplementa nenhuma regra de negócio: toda a validação é
+delegada ao `RoDouConfig` (Pydantic) definido em `src/schemas.py`, a mesma
+classe usada pelo `YAMLParser` para carregar as DAGs. O que o schema não
+valida, o CLI também não valida.
+
+Como o `schemas.py` importa `airflow.models.Variable` (via `ai/provider.py`),
+este script precisa rodar num ambiente com o Airflow instalado — na prática,
+dentro do container `airflow-webserver` (veja `make gerador-cli`).
+"""
+import argparse
+import os
+import re
+import sys
+
+import yaml
+from pydantic import ValidationError
+
+SRC_PATH = os.environ.get("RO_DOU_SRC_PATH", "/opt/airflow/dags/ro_dou_src")
+sys.path.insert(0, SRC_PATH)
+from schemas import RoDouConfig  # noqa: E402
+
+DAG_CONFS_DIR = os.environ.get(
+    "RO_DOU__DAG_CONF_DIR", "/opt/airflow/dags/ro_dou/dag_confs"
+)
+
+VERDE, AZUL, VERM, CINZA, RESET = (
+    "\033[32m", "\033[36m", "\033[31m", "\033[90m", "\033[0m"
+)
+
+FONTES = {"dou": "DOU", "inlabs": "INLABS", "qd": "QD"}
+
+
+# ---------------------------------------------------------------- interação
+
+def titulo(texto: str) -> None:
+    print(f"\n{AZUL}── {texto} ──{RESET}")
+
+
+def perguntar(
+    mensagem: str, dica: str | None = None, obrigatorio: bool = False
+) -> str | None:
+    if dica:
+        print(f"{CINZA}{dica}{RESET}")
+    marca = f"{VERM}*{RESET}" if obrigatorio else " "
+    while True:
+        valor = input(f"{marca} {mensagem}: ").strip()
+        if valor:
+            return valor
+        if not obrigatorio:
+            return None
+        print(f"{VERM}  ! Este campo é obrigatório.{RESET}")
+
+
+def perguntar_lista(
+    mensagem: str, dica: str | None = None, obrigatorio: bool = False
+) -> list[str] | None:
+    valor = perguntar(f"{mensagem} (separe por vírgula)", dica, obrigatorio)
+    if not valor:
+        return None
+    return [item.strip() for item in valor.split(",") if item.strip()]
+
+
+def perguntar_sim_nao(mensagem: str, default: bool = True) -> bool:
+    dica = "S/n" if default else "s/N"
+    while True:
+        valor = input(f"  {mensagem} ({dica}): ").strip().lower()
+        if not valor:
+            return default
+        if valor in ("s", "sim"):
+            return True
+        if valor in ("n", "nao", "não"):
+            return False
+        print(f"{VERM}  ! Responda com 's' ou 'n'.{RESET}")
+
+
+# ------------------------------------------------------- coleta interativa
+
+def coletar_id() -> str:
+    return perguntar(
+        "ID da DAG",
+        dica="ex.: monitoramento_dados_abertos (único, sem espaços)",
+        obrigatorio=True,
+    )
+
+
+def coletar_description() -> str:
+    return perguntar(
+        "Descrição da DAG",
+        dica="ex.: Monitora publicações sobre dados abertos no DOU",
+        obrigatorio=True,
+    )
+
+
+def coletar_schedule() -> str | None:
+    return perguntar(
+        "Agendamento cron",
+        dica="ex.: 0 8 * * MON-FRI — Enter usa o padrão do Ro-dou",
+    )
+
+
+def coletar_owner() -> list[str] | None:
+    return perguntar_lista("Owners/responsáveis pela DAG", dica="ex.: cginf")
+
+
+CAMPOS_SIMPLES = {
+    "id": coletar_id,
+    "description": coletar_description,
+    "schedule": coletar_schedule,
+    "owner": coletar_owner,
+}
+
+
+def coletar_search() -> dict:
+    titulo("Busca")
+    search = {}
+    sources = perguntar_lista("Fontes (DOU, INLABS, QD)", dica="Enter usa DOU")
+    if sources:
+        search["sources"] = [fonte.upper() for fonte in sources]
+    terms = perguntar_lista(
+        "Termos de pesquisa", dica="ex.: dados abertos, governo aberto"
+    )
+    if terms:
+        search["terms"] = terms
+    if "QD" in search.get("sources", []):
+        territory_id = perguntar(
+            "ID do município no Querido Diário (territory_id)",
+            dica="ex.: 4106902 (código IBGE)",
+        )
+        if territory_id:
+            search["territory_id"] = territory_id
+    return search
+
+
+def coletar_report() -> dict:
+    titulo("Relatório")
+    report = {}
+    emails = perguntar_lista(
+        "E-mails de destino do relatório", dica="ex.: pessoa@economia.gov.br"
+    )
+    if emails:
+        report["emails"] = emails
+    return report
+
+
+# ------------------------------------------------------------- validação
+
+def formatar_erros(exc: ValidationError) -> str:
+    erros = exc.errors()
+    erros_de_regra = [erro for erro in erros if erro["type"] == "value_error"]
+    if erros_de_regra:
+        erros = erros_de_regra
+    linhas = []
+    for erro in erros:
+        campo = ".".join(
+            str(parte) for parte in erro["loc"]
+            if not str(parte).startswith("function-after")
+        )
+        linhas.append(f"  - {campo}: {erro['msg']}" if campo else f"  - {erro['msg']}")
+    return "\n".join(linhas)
+
+
+def campo_do_erro(erro: dict) -> str:
+    """Extrai o campo de primeiro nível ('id', 'search', ...) de um erro
+    do Pydantic, para reperguntar somente o que falhou."""
+    loc = [
+        str(parte) for parte in erro["loc"]
+        if not str(parte).startswith("function-after")
+    ]
+    if loc and loc[0] == "dag":
+        loc = loc[1:]
+    if loc and loc[0] in (*CAMPOS_SIMPLES, "report"):
+        return loc[0]
+    return "search"
+
+
+# ----------------------------------------------------------- serialização
+
+def sem_sets(valor):
+    """Converte sets em listas ordenadas para permitir a serialização YAML."""
+    if isinstance(valor, set):
+        return sorted(sem_sets(item) for item in valor)
+    if isinstance(valor, dict):
+        return {chave: sem_sets(item) for chave, item in valor.items()}
+    if isinstance(valor, list):
+        return [sem_sets(item) for item in valor]
+    return valor
+
+
+class DumperIndentado(yaml.SafeDumper):
+    """Indenta itens de lista sob a chave, como nos exemplos de dag_confs/."""
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, False)
+
+
+def gerar_yaml(config: RoDouConfig) -> str:
+    dag_enxuto = config.dag.model_dump(exclude_defaults=True, exclude_none=True)
+    search = dag_enxuto.get("search")
+    if isinstance(search, list) and len(search) == 1:
+        dag_enxuto["search"] = search[0]
+    return yaml.dump(
+        {"dag": sem_sets(dag_enxuto)},
+        Dumper=DumperIndentado,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+
+
+RE_CHAVE = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_]*):( .*|)$")
+RE_ITEM = re.compile(r"^\s*- ")
+
+
+def colorir_yaml(texto: str) -> str:
+    linhas = []
+    for linha in texto.splitlines():
+        chave = RE_CHAVE.match(linha)
+        if chave:
+            indent, nome, valor = chave.groups()
+            linhas.append(f"{indent}{AZUL}{nome}{RESET}:{VERDE}{valor}{RESET}")
+        elif RE_ITEM.match(linha):
+            linhas.append(f"{VERDE}{linha}{RESET}")
+        else:
+            linhas.append(linha)
+    return "\n".join(linhas)
+
+
+# ------------------------------------------------------------------ saída
+
+def salvar_arquivo(
+    id_dag: str, yaml_texto: str, args: argparse.Namespace, interativo: bool
+) -> int:
+    caminho = args.output or os.path.join(DAG_CONFS_DIR, f"{id_dag}.yaml")
+    if os.path.exists(caminho) and not args.force:
+        if not interativo:
+            print(
+                f"{VERM}Arquivo {caminho} já existe — use --force para "
+                f"sobrescrever.{RESET}",
+                file=sys.stderr,
+            )
+            return 1
+        if not perguntar_sim_nao(
+            f"Arquivo {caminho} já existe. Sobrescrever?", default=False
+        ):
+            print("Operação cancelada, arquivo não foi salvo.")
+            return 0
+    try:
+        with open(caminho, "w", encoding="utf-8") as arquivo:
+            arquivo.write(yaml_texto)
+    except OSError as exc:
+        print(
+            f"{VERM}Não foi possível salvar em {caminho} ({exc.strerror}). "
+            f"Verifique as permissões do diretório ou use --stdout.{RESET}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"{VERDE}Arquivo salvo em {caminho}{RESET}")
+    return 0
+
+
+# ------------------------------------------------------------------ modos
+
+def modo_interativo(args: argparse.Namespace) -> int:
+    print(f"{AZUL}Gerador de YAML do Ro-dou{RESET}")
+    print(
+        f"{CINZA}Responda às perguntas abaixo; campos marcados com "
+        f"{VERM}*{CINZA} são obrigatórios,\nos demais podem ser pulados "
+        f"com Enter.{RESET}"
+    )
+
+    titulo("DAG")
+    dag_dict = {}
+    for campo, coletor in CAMPOS_SIMPLES.items():
+        valor = coletor()
+        if valor is not None:
+            dag_dict[campo] = valor
+    dag_dict["search"] = coletar_search()
+    dag_dict["report"] = coletar_report()
+
+    while True:
+        try:
+            config = RoDouConfig(dag=dag_dict)
+            break
+        except ValidationError as exc:
+            print(f"\n{VERM}A configuração informada é inválida:{RESET}")
+            print(f"{VERM}{formatar_erros(exc)}{RESET}")
+            print(f"{CINZA}Vamos corrigir apenas os campos com problema.{RESET}")
+            campos = dict.fromkeys(campo_do_erro(erro) for erro in exc.errors())
+            for campo in campos:
+                if campo in CAMPOS_SIMPLES:
+                    valor = CAMPOS_SIMPLES[campo]()
+                    if valor is None:
+                        dag_dict.pop(campo, None)
+                    else:
+                        dag_dict[campo] = valor
+                elif campo == "report":
+                    dag_dict["report"] = coletar_report()
+                else:
+                    dag_dict["search"] = coletar_search()
+
+    yaml_texto = gerar_yaml(config)
+    titulo("YAML gerado")
+    print(colorir_yaml(yaml_texto))
+    if args.stdout:
+        return 0
+    if not perguntar_sim_nao("Salvar este arquivo?"):
+        print("Arquivo não foi salvo.")
+        return 0
+    return salvar_arquivo(config.dag.id, yaml_texto, args, interativo=True)
+
+
+def montar_dag_dict(args: argparse.Namespace) -> dict:
+    search = {}
+    if args.sources:
+        search["sources"] = [FONTES[fonte] for fonte in args.sources]
+    if args.terms:
+        search["terms"] = args.terms
+    if args.territory_id is not None:
+        search["territory_id"] = args.territory_id
+    report = {}
+    if args.emails:
+        report["emails"] = args.emails
+    dag_dict = {"search": search, "report": report}
+    for campo in ("id", "description", "schedule"):
+        valor = getattr(args, campo)
+        if valor is not None:
+            dag_dict[campo] = valor
+    if args.owner:
+        dag_dict["owner"] = args.owner
+    return dag_dict
+
+
+def modo_direto(args: argparse.Namespace) -> int:
+    try:
+        config = RoDouConfig(dag=montar_dag_dict(args))
+    except ValidationError as exc:
+        print(f"{VERM}Configuração inválida:{RESET}", file=sys.stderr)
+        print(f"{VERM}{formatar_erros(exc)}{RESET}", file=sys.stderr)
+        return 1
+    yaml_texto = gerar_yaml(config)
+    if args.stdout:
+        print(yaml_texto, end="")
+        return 0
+    return salvar_arquivo(config.dag.id, yaml_texto, args, interativo=False)
+
+
+# ------------------------------------------------------------------- main
+
+FLAGS_CONFIG = (
+    "id", "description", "schedule", "owner",
+    "terms", "sources", "territory_id", "emails",
+)
+
+
+def montar_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Gera arquivos YAML de configuração de DAGs do Ro-dou. "
+        "Sem flags de configuração, roda em modo interativo.",
+        epilog="exemplo: %(prog)s --id minha_busca --description 'Minha busca' "
+        "--terms 'dados abertos' --emails pessoa@gov.br --stdout",
+    )
+    parser.add_argument("--id", help="nome único da DAG")
+    parser.add_argument("--description", help="descrição da DAG")
+    parser.add_argument("--schedule", help="expressão cron do agendamento")
+    parser.add_argument(
+        "--owner", action="append", metavar="NOME",
+        help="responsável pela DAG (repetível)",
+    )
+    parser.add_argument(
+        "--terms", action="append", metavar="TERMO",
+        help="termo de pesquisa (repetível)",
+    )
+    parser.add_argument(
+        "--sources", action="append", choices=sorted(FONTES),
+        help="fonte de dados (repetível; padrão: dou)",
+    )
+    parser.add_argument(
+        "--territory-id", type=int, metavar="ID",
+        help="ID do município no Querido Diário",
+    )
+    parser.add_argument(
+        "--emails", action="append", metavar="EMAIL",
+        help="e-mail de destino do relatório (repetível)",
+    )
+    parser.add_argument(
+        "--output", metavar="ARQUIVO",
+        help=f"arquivo de saída (padrão: {DAG_CONFS_DIR}/<id>.yaml)",
+    )
+    parser.add_argument(
+        "--stdout", action="store_true",
+        help="imprime o YAML em vez de salvar em arquivo",
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="sobrescreve o arquivo de saída sem perguntar",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = montar_parser().parse_args(argv)
+    modo_flags = any(
+        getattr(args, campo) is not None for campo in FLAGS_CONFIG
+    )
+    if modo_flags:
+        return modo_direto(args)
+    return modo_interativo(args)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (KeyboardInterrupt, EOFError):
+        print("\nOperação cancelada.")
+        sys.exit(130)

--- a/tools/gerador_cli.py
+++ b/tools/gerador_cli.py
@@ -10,7 +10,7 @@ valida, o CLI também não valida.
 
 Como o `schemas.py` importa `airflow.models.Variable` (via `ai/provider.py`),
 este script precisa rodar num ambiente com o Airflow instalado — na prática,
-dentro do container `airflow-webserver` (veja `make gerador-cli`).
+dentro do container `airflow-webserver` (veja `make gerar-yml`).
 """
 import argparse
 import os


### PR DESCRIPTION
## Descrição

Adiciona um gerador interativo de linha de comando (`tools/gerador_cli.py`, acionado via `make gerar-yml`) que complementa o gerador web já existente: ao invés de preencher um formulário no navegador, o usuário responde a um questionário no terminal e recebe o YAML de configuração da DAG pronto  impresso na tela ou salvo direto em `dag_confs/`.

Campos cobertos pelo questionário:
- **DAG**: `id`, `description`, `schedule`, `owner`, `callback` (e-mails de aviso em falha).
- **Search**: fonte única (`DOU`, `INLABS` ou `QD`), `terms`, `terms_ignore`, `dou_sections` (quando DOU/INLABS), `territory_id` (quando QD), e os booleanos exclusivos do INLABS `full_text`/`use_summary`/`show_relevancy`.
- **Report**: `emails`, `subject`, `attach_csv`, `skip_null`.

Quando o usuário aceita o valor padrão de um campo, ele simplesmente não entra no YAML gerado (o Ro-DOU já aplica o default na hora de carregar a DAG) — o arquivo final fica enxuto, no mesmo estilo dos exemplos em `dag_confs/`.

A documentação (`instalacao.md`, `parametros.md`, `faq.md`) foi atualizada para mencionar o `make gerar-yml` ao lado do gerador web.

## Tipo de mudança

- [ ] correção de bug
- [x] nova funcionalidade
- [ ] melhoria de código ou refatoração
- [ ] atualização de documentação

## Checklist

- [x] o código segue os padrões definidos no projeto
- [x] os testes existentes não foram quebrados 
- [x] a documentação foi atualizada
- [x] o ambiente de desenvolvimento foi testado com as mudanças

## Issue relacionada

resolve #310
