### PR TITLE
Add gitrysnc chart on Helm

### DIFF
--- a/helm/ro-dou/Chart.yaml
+++ b/helm/ro-dou/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ro-dou
 description: A Helm chart for Ro-dou project
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "latest"

--- a/helm/ro-dou/README.md
+++ b/helm/ro-dou/README.md
@@ -58,6 +58,19 @@ Os principais valores configuráveis são:
 | `airflow.dagProcessor.replicas` | Réplicas do processador de DAGs | `1` |
 | `airflow.pvc.storage` | Espaço solicitado para os logs do Airflow | `1Gi` |
 | `airflow.pvc.storageClassName` | `StorageClass` usada pelos logs do Airflow | `""` |
+| `gitRsync.enabled` | Sincroniza as configurações das DAGs de um repositório Git | `false` |
+| `gitRsync.schedule` | Agendamento do CronJob de sincronização | `*/5 * * * *` |
+| `gitRsync.repository` | URL HTTPS do repositório Git | `""` |
+| `gitRsync.branch` | Branch sincronizada | `main` |
+| `gitRsync.targetDir` | Diretório montado nos componentes do Airflow | `/opt/airflow/dags/ro_dou/dag_confs` |
+| `gitRsync.targetOwner.uid` | UID proprietário do diretório e dos arquivos sincronizados | `50000` |
+| `gitRsync.targetOwner.gid` | GID proprietário do diretório e dos arquivos sincronizados | `0` |
+| `gitRsync.secret.name` | Secret existente que contém o token Git; vazio para repositórios públicos | `""` |
+| `gitRsync.secret.key` | Chave do token dentro do Secret | `token` |
+| `gitRsync.persistence.existingClaim` | PVC existente para os arquivos sincronizados; vazio cria um PVC | `""` |
+| `gitRsync.persistence.storage` | Espaço solicitado para as configurações das DAGs | `1Gi` |
+| `gitRsync.persistence.storageClassName` | `StorageClass` usada pelas configurações das DAGs | `""` |
+| `gitRsync.persistence.accessMode` | Modo de acesso do PVC das configurações das DAGs | `ReadWriteOnce` |
 | `airflow.secrets.AIRFLOW__CORE__FERNET_KEY` | Chave Fernet usada pelo Airflow | valor de desenvolvimento |
 | `airflow.secrets.AIRFLOW__API_AUTH__JWT_SECRET` | Chave de assinatura dos tokens JWT | valor de desenvolvimento |
 | `airflow.secrets.AIRFLOW__API__SECRET_KEY` | Chave secreta do servidor de API | valor de desenvolvimento |
@@ -140,7 +153,7 @@ airflow:
 
 Quando `opensearch.connection.host` fica vazio, o chart configura o Airflow
 com a URL interna do Service criado para o release, por exemplo
-`http://meu-rodou-ro-dou-opensearch:9200`.
+`http://rodou-ro-dou-opensearch:9200`.
 
 Para utilizar uma instalação externa, mantenha `opensearch.enabled: false` e
 informe a URL externa:
@@ -157,6 +170,40 @@ airflow:
     OPENSEARCH_USER: usuario
     OPENSEARCH_PASS: senha-segura
 ```
+
+## Sincronização das configurações das DAGs via Git
+
+O git-rsync é desabilitado por padrão. Quando habilitado, o chart cria um
+CronJob e, salvo quando `existingClaim` é informado, um PVC dedicado. Esse PVC
+é montado no servidor de API, scheduler e processador de DAGs do Airflow. Após
+cada sincronização, o CronJob define o proprietário do diretório e de seus
+arquivos como UID `50000` e GID `0`, usados pela imagem oficial do Airflow.
+
+Para um repositório público:
+
+```yaml
+gitRsync:
+  enabled: true
+  repository: https://github.com/sua-organizacao/dag-confs.git
+  branch: main
+```
+
+Para um repositório privado, crie previamente um Secret com um token HTTPS e
+informe seu nome:
+
+```bash
+kubectl create secret generic git-token --from-literal=token=SEU_TOKEN
+```
+
+```yaml
+gitRsync:
+  enabled: true
+  repository: https://github.com/sua-organizacao/dag-confs.git
+  secret:
+    name: git-token
+    key: token
+```
+
 
 ## Serviços
 
@@ -183,34 +230,7 @@ kubectl port-forward service/rodou-ro-dou-smtp4dev 5001:5001
 ## Persistência
 
 O chart cria um PVC para os logs do Airflow, um volume persistente para os
-dados do PostgreSQL e, quando habilitado, outro para o OpenSearch. Ajuste a
-`StorageClass` e o tamanho dos volumes de acordo com o cluster antes da
-instalação.
+dados do PostgreSQL e, quando habilitados, volumes para o OpenSearch e o
+git-rsync. Ajuste a `StorageClass`, o modo de acesso e o tamanho dos volumes de
+acordo com o cluster antes da instalação.
 
-## Segredos
-
-O chart fornece credenciais e chaves padrão apenas para facilitar ambientes de
-desenvolvimento. Antes de uma instalação compartilhada ou de produção,
-substitua as chaves do Airflow, o administrador inicial e as credenciais do
-PostgreSQL em um arquivo de valores protegido:
-
-```yaml
-airflow:
-  secrets:
-    AIRFLOW__CORE__FERNET_KEY: <fernet-key>
-    AIRFLOW__API_AUTH__JWT_SECRET: <jwt-secret>
-    AIRFLOW__API__SECRET_KEY: <api-secret>
-    _AIRFLOW_WWW_USER_USERNAME: <usuario-administrador>
-    _AIRFLOW_WWW_USER_PASSWORD: <senha-administrador>
-
-postgres:
-  secrets:
-    postgres-user: <usuario-postgresql>
-    postgres-password: <senha-postgresql>
-    postgres-db: airflow
-```
-
-Não versione o arquivo que contém os valores reais. Em ambientes de produção,
-prefira ainda integrar o processo de instalação a um gerenciador externo de
-segredos. Os valores padrão nunca devem ser reutilizados fora de ambientes de
-desenvolvimento.

--- a/helm/ro-dou/templates/_helpers.tpl
+++ b/helm/ro-dou/templates/_helpers.tpl
@@ -51,6 +51,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Name of the PVC shared by git-rsync and the Airflow workloads.
+*/}}
+{{- define "ro-dou.gitRsync.claimName" -}}
+{{- default (printf "%s-dag-confs-pvc" (include "ro-dou.fullname" .)) .Values.gitRsync.persistence.existingClaim -}}
+{{- end }}
+
+{{/*
 Shell snippet that blocks until the Postgres service is accepting TCP connections.
 Hooks only guarantee Postgres has been created, not that it is ready, so jobs that
 talk to it must wait themselves.

--- a/helm/ro-dou/templates/airflow-api-server-deployment.yaml
+++ b/helm/ro-dou/templates/airflow-api-server-deployment.yaml
@@ -44,10 +44,20 @@ spec:
           volumeMounts:
             - name: airflow-logs
               mountPath: /opt/airflow/logs
+            {{- if .Values.gitRsync.enabled }}
+            - name: dag-confs
+              mountPath: {{ .Values.gitRsync.targetDir | quote }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: airflow-logs
           persistentVolumeClaim:
             claimName: {{ include "ro-dou.fullname" . }}-airflow-logs-pvc
+        {{- if .Values.gitRsync.enabled }}
+        - name: dag-confs
+          persistentVolumeClaim:
+            claimName: {{ include "ro-dou.gitRsync.claimName" . }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/ro-dou/templates/airflow-dag-processor-deployment.yaml
+++ b/helm/ro-dou/templates/airflow-dag-processor-deployment.yaml
@@ -30,7 +30,17 @@ spec:
           volumeMounts:
             - name: airflow-logs
               mountPath: /opt/airflow/logs
+            {{- if .Values.gitRsync.enabled }}
+            - name: dag-confs
+              mountPath: {{ .Values.gitRsync.targetDir | quote }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: airflow-logs
           persistentVolumeClaim:
             claimName: {{ include "ro-dou.fullname" . }}-airflow-logs-pvc
+        {{- if .Values.gitRsync.enabled }}
+        - name: dag-confs
+          persistentVolumeClaim:
+            claimName: {{ include "ro-dou.gitRsync.claimName" . }}
+        {{- end }}

--- a/helm/ro-dou/templates/airflow-scheduler-deployment.yaml
+++ b/helm/ro-dou/templates/airflow-scheduler-deployment.yaml
@@ -30,7 +30,17 @@ spec:
           volumeMounts:
             - name: airflow-logs
               mountPath: /opt/airflow/logs
+            {{- if .Values.gitRsync.enabled }}
+            - name: dag-confs
+              mountPath: {{ .Values.gitRsync.targetDir | quote }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: airflow-logs
           persistentVolumeClaim:
             claimName: {{ include "ro-dou.fullname" . }}-airflow-logs-pvc
+        {{- if .Values.gitRsync.enabled }}
+        - name: dag-confs
+          persistentVolumeClaim:
+            claimName: {{ include "ro-dou.gitRsync.claimName" . }}
+        {{- end }}

--- a/helm/ro-dou/templates/git-rsync.yaml
+++ b/helm/ro-dou/templates/git-rsync.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.gitRsync.enabled }}
+{{- if not .Values.gitRsync.persistence.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ro-dou.gitRsync.claimName" . }}
+  labels:
+    {{- include "ro-dou.labels" . | nindent 4 }}
+    app: git-rsync
+spec:
+  accessModes:
+    - {{ .Values.gitRsync.persistence.accessMode }}
+  {{- if .Values.gitRsync.persistence.storageClassName }}
+  storageClassName: {{ .Values.gitRsync.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.gitRsync.persistence.storage }}
+---
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ro-dou.fullname" . }}-git-rsync-scripts
+  labels:
+    {{- include "ro-dou.labels" . | nindent 4 }}
+    app: git-rsync
+data:
+  git-rsync.sh: |
+    #!/bin/sh
+    set -eu
+
+    workspace="$(mktemp -d)"
+    workdir="$workspace/repo"
+    trap 'rm -rf "$workspace"' EXIT
+
+    git_clone() {
+      if [ -n "${GIT_TOKEN:-}" ]; then
+        askpass="$workspace/git-askpass.sh"
+        printf '%s\n' \
+          '#!/bin/sh' \
+          'case "$1" in' \
+          '  *Username*) printf "%s\n" "x-access-token" ;;' \
+          '  *Password*) printf "%s\n" "$GIT_TOKEN" ;;' \
+          '  *) exit 1 ;;' \
+          'esac' > "$askpass"
+        chmod 0700 "$askpass"
+        GIT_ASKPASS="$askpass" GIT_TERMINAL_PROMPT=0 git "$@"
+      else
+        git "$@"
+      fi
+    }
+
+    git_clone clone --branch "$GIT_BRANCH" --depth 1 "$GIT_REPO" "$workdir"
+    mkdir -p "$TARGET_DIR"
+    rsync -a --delete --exclude=.git "$workdir/" "$TARGET_DIR/"
+    chown -R "$TARGET_UID:$TARGET_GID" "$TARGET_DIR"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "ro-dou.fullname" . }}-git-rsync-dag-confs
+  labels:
+    {{- include "ro-dou.labels" . | nindent 4 }}
+    app: git-rsync
+spec:
+  schedule: {{ .Values.gitRsync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: git-rsync
+            app.kubernetes.io/instance: {{ .Release.Name }}
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: git-rsync
+              image: {{ printf "%s:%s" .Values.gitRsync.image.repository .Values.gitRsync.image.tag | quote }}
+              imagePullPolicy: {{ .Values.gitRsync.image.pullPolicy }}
+              command:
+                - /bin/sh
+                - -c
+                - apk add --no-cache git rsync ca-certificates && /scripts/git-rsync.sh
+              env:
+                - name: GIT_REPO
+                  value: {{ required "gitRsync.repository is required when gitRsync is enabled" .Values.gitRsync.repository | quote }}
+                - name: GIT_BRANCH
+                  value: {{ .Values.gitRsync.branch | quote }}
+                - name: TARGET_DIR
+                  value: {{ .Values.gitRsync.targetDir | quote }}
+                - name: TARGET_UID
+                  value: {{ .Values.gitRsync.targetOwner.uid | quote }}
+                - name: TARGET_GID
+                  value: {{ .Values.gitRsync.targetOwner.gid | quote }}
+                {{- if .Values.gitRsync.secret.name }}
+                - name: GIT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.gitRsync.secret.name | quote }}
+                      key: {{ .Values.gitRsync.secret.key | quote }}
+                {{- end }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: dag-confs
+                  mountPath: {{ .Values.gitRsync.targetDir | quote }}
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "ro-dou.fullname" . }}-git-rsync-scripts
+                defaultMode: 0755
+            - name: dag-confs
+              persistentVolumeClaim:
+                claimName: {{ include "ro-dou.gitRsync.claimName" . }}
+{{- end }}

--- a/helm/ro-dou/values.yaml
+++ b/helm/ro-dou/values.yaml
@@ -47,6 +47,33 @@ airflow:
     storage: 1Gi
     storageClassName: ""
 
+# Synchronize DAG configuration files from Git (optional)
+gitRsync:
+  enabled: false
+  schedule: "*/5 * * * *"
+  image:
+    repository: alpine
+    tag: "3.18"
+    pullPolicy: IfNotPresent
+  repository: ""
+  branch: main
+  targetDir: /opt/airflow/dags/ro_dou/dag_confs
+  targetOwner:
+    # The official Airflow image runs as UID 50000 in the root group.
+    uid: 50000
+    gid: 0
+  secret:
+    # Name of an existing Secret containing a Git HTTPS token. Leave empty for
+    # public repositories.
+    name: ""
+    key: token
+  persistence:
+    # Use an existing claim instead of creating one when this value is set.
+    existingClaim: ""
+    storage: 1Gi
+    storageClassName: ""
+    accessMode: ReadWriteOnce
+
 # PostgreSQL configuration
 postgres:
   image:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -128,10 +128,12 @@ configurações das DAGs em uma pasta `dag_confs/`. Para sincronizar essas
 configurações a partir de um repositório Git sem rebuildar imagens, há um
 exemplo de solução `git-rsync` em `k8s/git-rsync/` que:
 
-- provê um `ConfigMap` com um script `git-rsync.sh` que faz `git clone`/
-   `git pull` e usa `rsync` para atualizar o diretório alvo;
+- provê um `ConfigMap` com um script `git-rsync.sh` que faz um clone raso e
+   usa `rsync` para atualizar o diretório alvo;
 - provê um `CronJob` que executa o script periodicamente (padrão: a cada
-   5 minutos).
+   5 minutos);
+- provê um PVC dedicado e patches opcionais que o montam, somente para
+   leitura, no servidor de API, scheduler e processador de DAGs do Airflow.
 
 Como usar (passos rápidos):
 
@@ -139,7 +141,15 @@ Como usar (passos rápidos):
     `GIT_BRANCH`. O manifesto `dag-confs-pvc.yml` cria, por padrão, um PVC de
     1 Gi chamado `dag-confs-pvc`; ajuste-o se precisar de outra capacidade,
     classe de armazenamento ou modo de acesso.
-2. Aplique os manifests:
+2. Para um repositório privado, crie um Secret com um token (PAT) HTTPS. Um
+    PAT classic precisa apenas do escopo `repo`; o escopo `user` não é
+    necessário. Pule este passo para repositórios públicos:
+
+```bash
+kubectl -n airflow-rodou create secret generic git-token --from-literal=token=YOUR_GITHUB_TOKEN
+```
+
+3. Aplique os manifests:
 
 ```bash
 kubectl -n airflow-rodou apply -f k8s/git-rsync/dag-confs-pvc.yml
@@ -147,9 +157,16 @@ kubectl -n airflow-rodou apply -f k8s/git-rsync/git-rsync-configmap.yml
 kubectl -n airflow-rodou apply -f k8s/git-rsync/git-rsync-cronjob.yml
 ```
 
-3. Para repositórios privados, prefira usar um token (PAT) via HTTPS:
+4. Aplique os patches para montar o PVC nos três Deployments do Airflow:
 
 ```bash
-kubectl -n airflow-rodou create secret generic git-token --from-literal=token=YOUR_GITHUB_TOKEN
-kubectl -n airflow-rodou apply -f k8s/git-rsync/git-rsync-cronjob.yml
+kubectl -n airflow-rodou patch deployment airflow-api-server --type=strategic --patch-file k8s/git-rsync/airflow-api-server-volume-patch.yml
+kubectl -n airflow-rodou patch deployment airflow-scheduler --type=strategic --patch-file k8s/git-rsync/airflow-scheduler-volume-patch.yml
+kubectl -n airflow-rodou patch deployment airflow-dag-processor --type=strategic --patch-file k8s/git-rsync/airflow-dag-processor-volume-patch.yml
 ```
+
+O token é fornecido ao Git de forma não interativa por `GIT_ASKPASS`, sem ser
+incluído na URL ou nos logs. Após cada sincronização, o CronJob altera o
+proprietário do diretório e dos arquivos para UID `50000` e GID `0`, usados
+pela imagem oficial do Airflow.
+

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -135,11 +135,14 @@ exemplo de solução `git-rsync` em `k8s/git-rsync/` que:
 
 Como usar (passos rápidos):
 
-1. Ajuste `k8s/git-rsync/git-rsync-cronjob.yml` definindo `GIT_REPO`,
-    `GIT_BRANCH` e substitua `dag-confs-pvc` pelo nome do seu PVC destino.
+1. Ajuste `k8s/git-rsync/git-rsync-cronjob.yml` definindo `GIT_REPO` e
+    `GIT_BRANCH`. O manifesto `dag-confs-pvc.yml` cria, por padrão, um PVC de
+    1 Gi chamado `dag-confs-pvc`; ajuste-o se precisar de outra capacidade,
+    classe de armazenamento ou modo de acesso.
 2. Aplique os manifests:
 
 ```bash
+kubectl -n airflow-rodou apply -f k8s/git-rsync/dag-confs-pvc.yml
 kubectl -n airflow-rodou apply -f k8s/git-rsync/git-rsync-configmap.yml
 kubectl -n airflow-rodou apply -f k8s/git-rsync/git-rsync-cronjob.yml
 ```
@@ -150,4 +153,3 @@ kubectl -n airflow-rodou apply -f k8s/git-rsync/git-rsync-cronjob.yml
 kubectl -n airflow-rodou create secret generic git-token --from-literal=token=YOUR_GITHUB_TOKEN
 kubectl -n airflow-rodou apply -f k8s/git-rsync/git-rsync-cronjob.yml
 ```
-

--- a/k8s/git-rsync/airflow-api-server-volume-patch.yml
+++ b/k8s/git-rsync/airflow-api-server-volume-patch.yml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-api-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: airflow-api-server
+          volumeMounts:
+            - name: dag-confs
+              mountPath: /opt/airflow/dags/ro_dou/dag_confs
+              readOnly: true
+      volumes:
+        - name: dag-confs
+          persistentVolumeClaim:
+            claimName: dag-confs-pvc

--- a/k8s/git-rsync/airflow-dag-processor-volume-patch.yml
+++ b/k8s/git-rsync/airflow-dag-processor-volume-patch.yml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-dag-processor
+spec:
+  template:
+    spec:
+      containers:
+        - name: airflow-dag-processor
+          volumeMounts:
+            - name: dag-confs
+              mountPath: /opt/airflow/dags/ro_dou/dag_confs
+              readOnly: true
+      volumes:
+        - name: dag-confs
+          persistentVolumeClaim:
+            claimName: dag-confs-pvc

--- a/k8s/git-rsync/airflow-scheduler-volume-patch.yml
+++ b/k8s/git-rsync/airflow-scheduler-volume-patch.yml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-scheduler
+spec:
+  template:
+    spec:
+      containers:
+        - name: airflow-scheduler
+          volumeMounts:
+            - name: dag-confs
+              mountPath: /opt/airflow/dags/ro_dou/dag_confs
+              readOnly: true
+      volumes:
+        - name: dag-confs
+          persistentVolumeClaim:
+            claimName: dag-confs-pvc

--- a/k8s/git-rsync/dag-confs-pvc.yml
+++ b/k8s/git-rsync/dag-confs-pvc.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dag-confs-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/git-rsync/dag-confs-pvc.yml
+++ b/k8s/git-rsync/dag-confs-pvc.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: dag-confs-pvc
+  labels:
+    app: git-rsync
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8s/git-rsync/git-rsync-configmap.yml
+++ b/k8s/git-rsync/git-rsync-configmap.yml
@@ -7,52 +7,41 @@ metadata:
 data:
   git-rsync.sh: |
     #!/bin/sh
-    set -e
+    set -eu
 
     GIT_REPO="${GIT_REPO:-}"
     GIT_BRANCH="${GIT_BRANCH:-main}"
     TARGET_DIR="${TARGET_DIR:-/opt/airflow/dags/ro_dou/dag_confs}"
-    WORKDIR="/tmp/repo"
-
-    # Authentication should use GIT_TOKEN (PAT)
+    TARGET_UID="${TARGET_UID:-50000}"
+    TARGET_GID="${TARGET_GID:-0}"
 
     if [ -z "$GIT_REPO" ]; then
       echo "GIT_REPO is not set"
       exit 1
     fi
 
-    echo "Using GIT_REPO=$GIT_REPO branch=$GIT_BRANCH"
+    workspace="$(mktemp -d)"
+    workdir="$workspace/repo"
+    trap 'rm -rf "$workspace"' EXIT
 
-    # If a token is provided via env GIT_TOKEN, use it for HTTPS auth
-    if [ -n "$GIT_TOKEN" ]; then
-      echo "Using token authentication (https)"
-      # do not expose token in logs
-      GIT_HTTP_HEADER="http.extraHeader=Authorization: Bearer $GIT_TOKEN"
-      GIT_AUTH_OPTS="-c \"$GIT_HTTP_HEADER\""
-    else
-      GIT_AUTH_OPTS=""
-    fi
-
-    if [ -d "$WORKDIR/.git" ]; then
-      echo "Updating existing clone"
-      cd "$WORKDIR"
-      if [ -n "$GIT_AUTH_OPTS" ]; then
-        eval git $GIT_AUTH_OPTS fetch --all --prune
-        eval git $GIT_AUTH_OPTS reset --hard "origin/$GIT_BRANCH"
+    git_clone() {
+      if [ -n "${GIT_TOKEN:-}" ]; then
+        askpass="$workspace/git-askpass.sh"
+        printf '%s\n' \
+          '#!/bin/sh' \
+          'case "$1" in' \
+          '  *Username*) printf "%s\n" "x-access-token" ;;' \
+          '  *Password*) printf "%s\n" "$GIT_TOKEN" ;;' \
+          '  *) exit 1 ;;' \
+          'esac' > "$askpass"
+        chmod 0700 "$askpass"
+        GIT_ASKPASS="$askpass" GIT_TERMINAL_PROMPT=0 git "$@"
       else
-        git fetch --all --prune
-        git reset --hard "origin/$GIT_BRANCH"
+        git "$@"
       fi
-    else
-      echo "Cloning repository"
-      rm -rf "$WORKDIR"
-      if [ -n "$GIT_AUTH_OPTS" ]; then
-        eval git $GIT_AUTH_OPTS clone --branch "$GIT_BRANCH" "$GIT_REPO" "$WORKDIR"
-      else
-        git clone --branch "$GIT_BRANCH" "$GIT_REPO" "$WORKDIR"
-      fi
-    fi
+    }
 
-    echo "Syncing to $TARGET_DIR"
+    git_clone clone --branch "$GIT_BRANCH" --depth 1 "$GIT_REPO" "$workdir"
     mkdir -p "$TARGET_DIR"
-    rsync -av --delete "$WORKDIR/" "$TARGET_DIR/"
+    rsync -a --delete --exclude=.git "$workdir/" "$TARGET_DIR/"
+    chown -R "$TARGET_UID:$TARGET_GID" "$TARGET_DIR"

--- a/k8s/git-rsync/git-rsync-cronjob.yml
+++ b/k8s/git-rsync/git-rsync-cronjob.yml
@@ -2,18 +2,25 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: git-rsync-dag-confs
+  labels:
+    app: git-rsync
 spec:
   schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: git-rsync
         spec:
           restartPolicy: OnFailure
           containers:
             - name: git-rsync
               image: alpine:3.18
+              imagePullPolicy: IfNotPresent
               command: ["/bin/sh", "-c", "apk add --no-cache git rsync ca-certificates && /scripts/git-rsync.sh"]
               env:
                 - name: GIT_REPO
@@ -22,11 +29,16 @@ spec:
                   value: "main"
                 - name: TARGET_DIR
                   value: "/opt/airflow/dags/ro_dou/dag_confs"
+                - name: TARGET_UID
+                  value: "50000"
+                - name: TARGET_GID
+                  value: "0"
                 - name: GIT_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: git-token
                       key: token
+                      optional: true
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
@@ -40,4 +52,3 @@ spec:
             - name: dag-confs
               persistentVolumeClaim:
                 claimName: dag-confs-pvc
-            # Use HTTPS+token (PAT) for authentication.


### PR DESCRIPTION
# Summary

Adds persistent, Git-based synchronization on Helm.

## Changes

- Add the missing `dag-confs-pvc` Kubernetes manifest.
- Add configurable git-rsync support to the Helm chart.
- Create a CronJob and ConfigMap for periodically synchronizing a Git repository.
- Support private GitHub repositories through an existing Kubernetes Secret.
- Authenticate non-interactively using `GIT_ASKPASS`, keeping the PAT out of repository URLs and logs.
- Restore synchronized file ownership to the configurable Airflow UID/GID (`50000:0` by default).
- Document configuration, storage access modes, authentication, and usage.
- Bump the Helm chart version to `0.5.0`.

