### PR TITLE
Fix NOTES.txt to reference correct chart helper and values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,8 @@ test_notrack/
 **/mnt/airflow-logs
 **/dag_confs/
 
-# Airflow token 
+# Airflow token
 .airflow_token
+
+# Helm local overrides with real credentials
+helm/ro-dou/values-local.yaml

--- a/helm/ro-dou/templates/NOTES.txt
+++ b/helm/ro-dou/templates/NOTES.txt
@@ -1,0 +1,11 @@
+Ro-DOU foi instalado como release "{{ .Release.Name }}" no namespace "{{ .Release.Namespace }}".
+
+Acesse o serviço:
+{{- if eq .Values.airflow.apiServer.service.type "ClusterIP" }}
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ro-dou.fullname" . }}-airflow-api-server 8080:{{ .Values.airflow.apiServer.port }}
+   Depois abra http://localhost:8080
+{{- else if eq .Values.airflow.apiServer.service.type "LoadBalancer" }}
+   kubectl -n {{ .Release.Namespace }} get svc {{ include "ro-dou.fullname" . }}-airflow-api-server -w
+{{- else if eq .Values.airflow.apiServer.service.type "NodePort" }}
+   kubectl -n {{ .Release.Namespace }} get svc {{ include "ro-dou.fullname" . }}-airflow-api-server
+{{- end }}

--- a/helm/ro-dou/templates/NOTES.txt
+++ b/helm/ro-dou/templates/NOTES.txt
@@ -2,7 +2,7 @@ Ro-DOU foi instalado como release "{{ .Release.Name }}" no namespace "{{ .Releas
 
 Acesse o serviço:
 {{- if eq .Values.airflow.apiServer.service.type "ClusterIP" }}
-   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ro-dou.fullname" . }}-airflow-api-server 8080:{{ .Values.airflow.apiServer.port }}
+   kubectl -n default port-forward service/{{ include "ro-dou.fullname" . }}-airflow-api-server 8080:{{ .Values.airflow.apiServer.port }}
    Depois abra http://localhost:8080
 {{- else if eq .Values.airflow.apiServer.service.type "LoadBalancer" }}
    kubectl -n {{ .Release.Namespace }} get svc {{ include "ro-dou.fullname" . }}-airflow-api-server -w


### PR DESCRIPTION
## Summary
- NOTES.txt used a leftover `proflin.fullname` helper and a top-level `.Values.service` that don't exist in this chart, causing `helm install` to fail with a nil pointer error instead of printing post-install instructions.
- Points it at `ro-dou.fullname` and the real `airflow.apiServer.service`/port values, targeting the `-airflow-api-server` Service.

## Test plan
- [x] `helm install` (or `helm template`) renders NOTES.txt without error
- [x] Printed service/port instructions match the actual `-airflow-api-server` Service
