### PR TITLE
feat(helm): support repository subdirectory sync and proxy configuration

### DIFF
--- a/helm/ro-dou/README.md
+++ b/helm/ro-dou/README.md
@@ -68,6 +68,7 @@ Os principais valores configuráveis são:
 | `gitRsync.schedule` | Agendamento do CronJob de sincronização | `*/5 * * * *` |
 | `gitRsync.repository` | URL HTTPS do repositório Git | `""` |
 | `gitRsync.branch` | Branch sincronizada | `main` |
+| `gitRsync.sourceDir` | Diretório relativo dentro do repositório; vazio sincroniza a raiz | `""` |
 | `gitRsync.targetDir` | Diretório montado nos componentes do Airflow | `/opt/airflow/dags/ro_dou/dag_confs` |
 | `gitRsync.targetOwner.uid` | UID proprietário do diretório e dos arquivos sincronizados | `50000` |
 | `gitRsync.targetOwner.gid` | GID proprietário do diretório e dos arquivos sincronizados | `0` |

--- a/helm/ro-dou/templates/git-rsync.yaml
+++ b/helm/ro-dou/templates/git-rsync.yaml
@@ -52,8 +52,20 @@ data:
     }
 
     git_clone clone --branch "$GIT_BRANCH" --depth 1 "$GIT_REPO" "$workdir"
+    case "$GIT_SOURCE_DIR" in
+      ""|.) source_dir="$workdir" ;;
+      /*|..|../*|*/..|*/../*)
+        echo "GIT_SOURCE_DIR must be a relative path inside the repository" >&2
+        exit 1
+        ;;
+      *) source_dir="$workdir/$GIT_SOURCE_DIR" ;;
+    esac
+    if [ ! -d "$source_dir" ]; then
+      echo "Git source directory does not exist: $GIT_SOURCE_DIR" >&2
+      exit 1
+    fi
     mkdir -p "$TARGET_DIR"
-    rsync -a --delete --exclude=.git "$workdir/" "$TARGET_DIR/"
+    rsync -a --delete --exclude=.git "$source_dir/" "$TARGET_DIR/"
     chown -R "$TARGET_UID:$TARGET_GID" "$TARGET_DIR"
 ---
 apiVersion: batch/v1
@@ -96,6 +108,8 @@ spec:
                   value: {{ required "gitRsync.repository is required when gitRsync is enabled" .Values.gitRsync.repository | quote }}
                 - name: GIT_BRANCH
                   value: {{ .Values.gitRsync.branch | quote }}
+                - name: GIT_SOURCE_DIR
+                  value: {{ .Values.gitRsync.sourceDir | quote }}
                 - name: TARGET_DIR
                   value: {{ .Values.gitRsync.targetDir | quote }}
                 - name: TARGET_UID

--- a/helm/ro-dou/templates/git-rsync.yaml
+++ b/helm/ro-dou/templates/git-rsync.yaml
@@ -86,6 +86,12 @@ spec:
                 - -c
                 - apk add --no-cache git rsync ca-certificates && /scripts/git-rsync.sh
               env:
+                - name: HTTP_PROXY
+                  value: {{ .Values.gitRsync.env.HTTP_PROXY | quote }}
+                - name: HTTPS_PROXY
+                  value: {{ .Values.gitRsync.env.HTTPS_PROXY | quote }}
+                - name: NO_PROXY
+                  value: {{ .Values.gitRsync.env.NO_PROXY | quote }}
                 - name: GIT_REPO
                   value: {{ required "gitRsync.repository is required when gitRsync is enabled" .Values.gitRsync.repository | quote }}
                 - name: GIT_BRANCH

--- a/helm/ro-dou/values.yaml
+++ b/helm/ro-dou/values.yaml
@@ -73,6 +73,9 @@ gitRsync:
     pullPolicy: IfNotPresent
   repository: ""
   branch: main
+  # Relative folder inside the repository to synchronize. Leave empty to
+  # synchronize the repository root.
+  sourceDir: ""
   targetDir: /opt/airflow/dags/ro_dou/dag_confs
   targetOwner:
     # The official Airflow image runs as UID 50000 in the root group.

--- a/helm/ro-dou/values.yaml
+++ b/helm/ro-dou/values.yaml
@@ -63,6 +63,10 @@ airflow:
 gitRsync:
   enabled: false
   schedule: "*/5 * * * *"
+  env:
+    HTTP_PROXY: ""
+    HTTPS_PROXY: ""
+    NO_PROXY: ""
   image:
     repository: alpine
     tag: "3.18"


### PR DESCRIPTION
## Summary

Improves the Helm `gitRsync` configuration by supporting repository subdirectory synchronization and proxy settings.

## Changes

- Adds `gitRsync.sourceDir` to synchronize a specific folder from a repository.
- Adds `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` configuration for Git synchronization.
