### PR TITLE
fix: Corrigir identificação da primeira execução do dia considerando o timezone

### DIFF
--- a/dag_load_inlabs/ro_dou_inlabs_load_pg_dag.py
+++ b/dag_load_inlabs/ro_dou_inlabs_load_pg_dag.py
@@ -264,19 +264,21 @@ def load_inlabs():
 
         context = get_current_context()
         logical_date = context["logical_date"].in_timezone(AIRFLOW_TIMEZONE)
-        prev_end_date_success = context.get("prev_end_date_success")
-        if prev_end_date_success:
-            prev_end_date_success = prev_end_date_success.in_timezone(AIRFLOW_TIMEZONE)
+        prev_start_date_success = context.get("prev_start_date_success")
+        if prev_start_date_success:
+            prev_start_date_success = prev_start_date_success.in_timezone(
+                AIRFLOW_TIMEZONE
+            )
         logging.info(
-            f"Logical date: {logical_date}, Previous successful end date: {prev_end_date_success}"
+            f"Logical date: {logical_date}, Previous successful start date: {prev_start_date_success}"
         )
 
-        if not prev_end_date_success:
+        if not prev_start_date_success:
             logging.info("Primeira execução da dag")
             logging.info("Triggering dataset e DAGs do INLABS")
             return "trigger_dataset_inlabs"
 
-        if prev_end_date_success.date() < logical_date.date():
+        if prev_start_date_success.date() < logical_date.date():
             logging.info("Primeira execução bem-sucedida do dia")
             logging.info("Triggering dataset e DAGs do INLABS")
             return "trigger_dataset_inlabs"

--- a/dag_load_inlabs/ro_dou_inlabs_load_pg_dag.py
+++ b/dag_load_inlabs/ro_dou_inlabs_load_pg_dag.py
@@ -260,10 +260,15 @@ def load_inlabs():
 
     @task.branch(trigger_rule="none_failed_min_one_success")
     def check_if_first_run_of_day():
+        from ro_dou_src.utils.date import AIRFLOW_TIMEZONE
 
         context = get_current_context()
-        logical_date = context["logical_date"]
+        logical_date = context["logical_date"].in_timezone(AIRFLOW_TIMEZONE)
         prev_end_date_success = context.get("prev_end_date_success")
+        if prev_end_date_success:
+            prev_end_date_success = prev_end_date_success.in_timezone(
+                AIRFLOW_TIMEZONE
+            )
         print(
             f"Logical date: {logical_date}, Previous successful end date: {prev_end_date_success}"
         )

--- a/dag_load_inlabs/ro_dou_inlabs_load_pg_dag.py
+++ b/dag_load_inlabs/ro_dou_inlabs_load_pg_dag.py
@@ -266,10 +266,8 @@ def load_inlabs():
         logical_date = context["logical_date"].in_timezone(AIRFLOW_TIMEZONE)
         prev_end_date_success = context.get("prev_end_date_success")
         if prev_end_date_success:
-            prev_end_date_success = prev_end_date_success.in_timezone(
-                AIRFLOW_TIMEZONE
-            )
-        print(
+            prev_end_date_success = prev_end_date_success.in_timezone(AIRFLOW_TIMEZONE)
+        logging.info(
             f"Logical date: {logical_date}, Previous successful end date: {prev_end_date_success}"
         )
 

--- a/src/ai/provider.py
+++ b/src/ai/provider.py
@@ -21,9 +21,9 @@ class AIProvider(str, Enum):
         if self != AIProvider.azure:
             raise ValueError("Azure config only applies to Azure provider")
 
-        endpoint = Variable.get("AZURE_OPENAI_ENDPOINT", default_var=None)
-        api_version = Variable.get("AZURE_OPENAI_API_VERSION", default_var=None)
-        deployment = Variable.get("AZURE_OPENAI_DEPLOYMENT", default_var=None)
+        endpoint = Variable.get("AZURE_OPENAI_ENDPOINT", default=None)
+        api_version = Variable.get("AZURE_OPENAI_API_VERSION", default=None)
+        deployment = Variable.get("AZURE_OPENAI_DEPLOYMENT", default=None)
 
         if not all([api_key, endpoint, api_version, deployment]):
             raise RuntimeError(

--- a/src/notification/failure_sender.py
+++ b/src/notification/failure_sender.py
@@ -74,7 +74,7 @@ class FailureSender:
 
         # Usa email admin padrão
         try:
-            email_admin = Variable.get("email_admin", default_var=None)
+            email_admin = Variable.get("email_admin", default=None)
             if email_admin:
                 return email_list + [email_admin]
             # Se email_admin não estiver configurado, verifica se há email no relatório do DAG


### PR DESCRIPTION
# Corrige classificação incorreta da primeira execução do dia na DAG ro-dou_inlabs_load_pg

## Descrição

A task `check_if_first_run_of_day` da DAG `ro-dou_inlabs_load_pg` comparava `logical_date` e `prev_end_date_success` diretamente em UTC (timezone padrão fornecido pelo contexto do Airflow), sem convertê-los para o timezone configurado no Airflow (`America/Sao_Paulo`). Como a regra de negócio depende do dia civil nesse timezone, execuções próximas à virada do dia (ex.: por volta de 03h59/06h59 UTC) podiam comparar datas que ainda pertenciam ao mesmo dia em UTC, mas já eram dias diferentes em São Paulo — fazendo a DAG tratar incorretamente a primeira execução do dia como uma edição extra (`trigger_dataset_inlabs_edicao_extra`), sem qualquer falha explícita.

A correção converte `logical_date` e `prev_end_date_success` para o timezone configurado (via `AIRFLOW_TIMEZONE`, já usado por `get_reference_date` em `ro_dou_src/utils/date.py`) antes de extrair `.date()` para a comparação, garantindo que a decisão siga o dia civil correto.

## Tipo de mudança

marque com um "x" o tipo de mudança que se aplica:

- [x] correção de bug
- [ ] nova funcionalidade
- [ ] melhoria de código ou refatoração
- [ ] atualização de documentação
- [ ] outra (descreva abaixo)

## Checklist

- [x] o código segue os padrões definidos no projeto
- [x] os testes existentes não foram quebrados
- [ ] a documentação foi atualizada (se aplicável)
- [ ] o ambiente de desenvolvimento foi testado com as mudanças
- [ ] o pull request está vinculado a uma issue (se aplicável)

## Issue relacionada

resolve #345 

